### PR TITLE
Redefined Coords in jrrle_backend.py

### DIFF
--- a/ggcmpy/jrrle_backend.py
+++ b/ggcmpy/jrrle_backend.py
@@ -83,8 +83,8 @@ def jrrle_open_dataset(filename_or_obj, *, drop_variables=None):
         # )  #  see also conventions.decode_cf_variables
 
     if meta["type"] == "iof":
-        coords = dict(lat=np.linspace(-90., 90., dims[1]),
-                      lon=np.linspace(0., 360., dims[0]))
+        coords = dict(lat=np.linspace(90., -90., dims[1]),
+                      lon=np.linspace(-180., 180., dims[0]))
 
     attrs = dict(run=meta["run"], dims=dims)
 


### PR DESCRIPTION
"jrrle_backend.jrrle_open_dataset: Redefined the coordinates to reflect the correct OpenGGCM ionosphere grids"