### PR TITLE
build: add "numpy" to build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ Homepage = "https://github.com/unh-hpc/ggcmpy"
 Issues = "https://github.com/unh-hpc/ggcmpy/issues"
 
 [build-system]
-requires = ["scikit-build-core"]
+requires = ["scikit-build-core", "numpy"]
 build-backend = "scikit_build_core.build"
 
 [project.entry-points."xarray.backends"]


### PR DESCRIPTION
Not sure that's the right way to do it, but without it, cmake complains that it can't find numpy and doesn't build ggcmpy, unless one builds it editable with no build isolation.

This way, everything works, I'm just confused why I have to add numpy to build dependencies when it's already listed as a dependency.