### PR TITLE
update jrrle reading

### DIFF
--- a/ggcmpy/backends/jrrle/jrrle_file.py
+++ b/ggcmpy/backends/jrrle/jrrle_file.py
@@ -37,7 +37,7 @@ class JrrleFile(FortranFile):
             tuple (field name, dict of meta data, array)
         """
         meta = self.inquire(fld_name)
-        arr = np.empty(meta["dims"], dtype="float32", order="F")
+        arr = np.empty(meta["shape"], dtype="float32", order="F")
         self._read_func[ndim - 1](self.unit, arr, fld_name, read_ascii)
         return meta, arr
 
@@ -110,13 +110,11 @@ class JrrleFile(FortranFile):
         if varname in self.fields_seen:
             meta = self.fields_seen[varname]
         else:
-            dims = tuple(x for x in (nx, ny, nz) if x > 0)
-
             meta = dict(
                 timestr=tstring,
                 inttime=it,
                 ndim=ndim,
-                dims=dims,
+                shape=tuple(x for x in (nx, ny, nz) if x > 0),
                 file_position=self.tell(),
             )
             self.fields_seen[varname] = meta

--- a/ggcmpy/jrrle_backend.py
+++ b/ggcmpy/jrrle_backend.py
@@ -70,7 +70,7 @@ def jrrle_open_dataset(filename_or_obj, *, drop_variables=None):
             ndim = flds[fld]["ndim"]
             fld_info, arr = f.read_field(fld, ndim)
             if shape is None:
-                shape = fld_info["dims"]
+                shape = fld_info["shape"]
             data_attrs = dict(inttime=fld_info["inttime"])
             data_attrs.update(openggcm.parse_timestring(fld_info["timestr"]))
 
@@ -80,8 +80,7 @@ def jrrle_open_dataset(filename_or_obj, *, drop_variables=None):
                 ), "inconsistent time info in jrrle file"
             time = data_attrs["time"]
 
-            vars[fld] = xr.DataArray(
-                data=arr, dims=data_dims, attrs=data_attrs)
+            vars[fld] = xr.DataArray(data=arr, dims=data_dims, attrs=data_attrs)
         # vars, attrs, coords = my_decode_variables(
         #     vars, attrs, decode_times, decode_timedelta, decode_coords
         # )  #  see also conventions.decode_cf_variables

--- a/ggcmpy/jrrle_backend.py
+++ b/ggcmpy/jrrle_backend.py
@@ -56,12 +56,13 @@ def jrrle_open_dataset(filename_or_obj, *, drop_variables=None):
     elif meta["type"] == "3df":
         data_dims = ["x", "y", "z"]
     elif meta["type"] == "iof":
-        data_dims = ["lon", "lat"]
+        data_dims = ["longs", "lats"]
 
     file_wrapper = jrrle.JrrleFile(filename_or_obj)
     file_wrapper.open()
     file_wrapper.inquire_all_fields()
 
+    time = None
     with file_wrapper as f:
         flds = f.fields_seen
         vars = {}
@@ -70,8 +71,14 @@ def jrrle_open_dataset(filename_or_obj, *, drop_variables=None):
             fld_info, arr = f.read_field(fld, ndim)
             if not dims:
                 dims = fld_info["dims"]
-            time, uttime = openggcm.parse_timestring(fld_info["timestr"])
-            data_attrs = dict(inttime=fld_info["inttime"], time=time, uttime=uttime)
+            data_attrs = dict(inttime=fld_info["inttime"])
+            data_attrs.update(openggcm.parse_timestring(fld_info["timestr"]))
+
+            if time is not None:
+                assert (
+                    time == data_attrs["time"]
+                ), "inconsistent time info in jrrle file"
+            time = data_attrs["time"]
 
             vars[fld] = xr.DataArray(data=arr, dims=data_dims, attrs=data_attrs)
         # vars, attrs, coords = my_decode_variables(
@@ -80,11 +87,13 @@ def jrrle_open_dataset(filename_or_obj, *, drop_variables=None):
 
     if meta["type"] == "iof":
         coords = dict(
-            lat=np.linspace(90.0, -90.0, dims[1]),
-            lon=np.linspace(-180.0, 180.0, dims[0]),
+            lats=("lats", np.linspace(90.0, -90.0, dims[1])),
+            colats=("lats", np.linspace(0.0, 180.0, dims[1])),
+            longs=("longs", np.linspace(-180.0, 180.0, dims[0])),
+            mlts=("longs", np.linspace(0.0, 24.0, dims[0])),
         )
 
-    attrs = dict(run=meta["run"], dims=dims)
+    attrs = dict(run=meta["run"], dims=dims, time=time)
 
     ds = xr.Dataset(vars, coords=coords, attrs=attrs)
     #    ds.set_close(my_close_method)

--- a/ggcmpy/openggcm.py
+++ b/ggcmpy/openggcm.py
@@ -29,5 +29,5 @@ def parse_timestring(timestr):
 
     return dict(
         elapsed_time=float(timestr[0]),
-        time=dt.datetime.strptime(timestr[2], "%Y:%m:%d:%H:%M:%S.%f"),
+        time=np.datetime64(dt.datetime.strptime(timestr[2], "%Y:%m:%d:%H:%M:%S.%f")),
     )

--- a/ggcmpy/openggcm.py
+++ b/ggcmpy/openggcm.py
@@ -1,4 +1,4 @@
-import re
+import datetime as dt
 import numpy as np
 from itertools import islice
 
@@ -22,65 +22,12 @@ def read_grid2(filename):
     return {"x": gx, "y": gy, "z": gz}
 
 
-def _as_isotime(time):
-    """Try to convert times in string format to ISO 8601
-
-    Raises:
-        TypeError: Elements are not strings
-        ValueError: numpy.datetime64(time) fails
-    """
-    if isinstance(time, (list, tuple, np.ndarray)):
-        scalar = False
-    else:
-        scalar = True
-        time = [time]
-
-    ret = [None] * len(time)
-    for i, t in enumerate(time):
-        t = t.strip().upper().lstrip("UT")
-        if re.match(r"^[0-9]{2}([0-9]{2}:){3,5}[0-9]{1,2}(\.[0-9]*)?$", t):
-            # Handle YYYY:MM:DD:hh:mm:ss.ms -> YYYY-MM-DDThh:mm:ss.ms
-            #        YYYY:MM:DD:hh:mm:s.ms  -> YYYY-MM-DDThh:mm:s.ms
-            #        YYYY:MM:DD:hh:mm:ss    -> YYYY-MM-DDThh:mm:ss
-            #        YYYY:MM:DD:hh:mm       -> YYYY-MM-DDThh:mm
-            #        YYYY:MM:DD:hh          -> YYYY-MM-DDThh
-            # -- all this _tsp nonsense is to take care of s.ms; annoying
-            _tsp = t.replace(".", ":").split(":")
-            _tsp[0] = _tsp[0].zfill(4)
-            _tsp[1:6] = [_s.zfill(2) for _s in _tsp[1:6]]
-            t = ":".join(_tsp[:6])
-            if len(_tsp) > 6:
-                t += "." + _tsp[6]
-            # --
-            ret[i] = t[:10].replace(":", "-") + "T" + t[11:]
-
-        elif re.match(r"^[0-9]{2}([0-9]{2}:){2}[0-9]{2}$", t):
-            # Handle YYYY:MM:DD -> YYYY-MM-DD
-            ret[i] = t.replace(":", "-")
-        else:
-            ret[i] = t
-
-        try:
-            np.datetime64(ret[i])
-        except ValueError:
-            raise
-
-    if scalar:
-        return ret[0]
-    else:
-        if isinstance(time, np.ndarray):
-            return np.array(time, dtype=time.dtype)
-        else:
-            return ret
-
-
 def parse_timestring(timestr):
-    prefix = "time="
-    timestr.strip()
-    if not timestr.startswith(prefix):
+    if not timestr.startswith("time="):
         raise ValueError("Time string '{0}' is malformed".format(timestr))
-    timestr = timestr[len(prefix) :].split()
-    t = float(timestr[0])
-    t = np.timedelta64(int(1000 * t), "ms")
-    uttime = np.datetime64(_as_isotime(timestr[2]))
-    return t, uttime
+    timestr = timestr[len("time=") :].split()
+
+    return dict(
+        elapsed_time=float(timestr[0]),
+        time=dt.datetime.strptime(timestr[2], "%Y:%m:%d:%H:%M:%S.%f"),
+    )


### PR DESCRIPTION
The basic idea here is to use this reader in the `ggcm-gitm-coupling-tools` set of tools, rather than that having its own
jrrle reading, which does mostly the same.

Unfortunately, the naming conventions aren't quite the same, so for now this updates the naming to follow what the other set of tools has, since that uses that naming consistently across a number of file formats. However, I don't actually like that naming as-is, either, so before we get stuck with it forever, we should agree upon a naming scheme and use it consistently.

In any case, for the time being, this is likely to break existing users of `ggcmpy` in that iof data now gets transposed, and the dims are renamed to `lats`, `longs`. 