### PR TITLE
ggcm accessor for coords handling

### DIFF
--- a/src/ggcmpy/openggcm.py
+++ b/src/ggcmpy/openggcm.py
@@ -157,5 +157,12 @@ class OpenGGCMAccessor:
         return "OpenGGCM accessor\n" + repr(self._coords)
 
     @property
-    def coords(self):
+    def coords(self) -> xr.Coordinates:
         return self._coords
+
+    def __getattr__(self, name: str) -> Any:
+        if name in self._coords:
+            return self._coords[name]
+
+        msg = f"Attribute {name} not found"
+        raise AttributeError(msg)

--- a/src/ggcmpy/openggcm.py
+++ b/src/ggcmpy/openggcm.py
@@ -141,9 +141,9 @@ def _dt64_to_time_array(times: ArrayLike, dtype: DTypeLike) -> ArrayLike:
 
 @xr.register_dataset_accessor("ggcm")  # type: ignore[no-untyped-call]
 class OpenGGCMAccessor:
-    def __init__(self, xarray_obj):
+    def __init__(self, xarray_obj: Any):
         self._obj = xarray_obj
-        self._coords = self._obj.coords
+        self._coords: xr.Coordinates = self._obj.coords
 
         if "colats" not in self._coords and "lats" in self._coords:
             self._coords = self._coords.assign(colats=90 - self._coords["lats"])
@@ -153,7 +153,7 @@ class OpenGGCMAccessor:
                 mlts=(self._coords["longs"] + 180) * 24 / 360,
             )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "OpenGGCM accessor\n" + repr(self._coords)
 
     @property

--- a/src/ggcmpy/openggcm.py
+++ b/src/ggcmpy/openggcm.py
@@ -47,14 +47,6 @@ def parse_timestring(timestr: str) -> dict[str, Any]:
 
 
 def decode_openggcm(ds: xr.Dataset) -> xr.Dataset:
-    # add colats and mlts as coordinates
-    # FIXME? not clear that this is the best place to do this
-    # if (
-    #     not {"colats", "mlts"} <= ds.coords.keys()
-    #     and {"lats", "longs"} <= ds.coords.keys()
-    # ):
-    #     ds = ds.assign_coords(colats=90 - ds.lats, mlts=(ds.longs + 180) * 24 / 360)
-
     for name, var in ds.variables.items():
         ds[name] = _decode_openggcm_variable(var, name)  # type: ignore[arg-type]
 

--- a/src/ggcmpy/openggcm.py
+++ b/src/ggcmpy/openggcm.py
@@ -134,6 +134,12 @@ def _dt64_to_time_array(times: ArrayLike, dtype: DTypeLike) -> ArrayLike:
 @xr.register_dataarray_accessor("ggcm")  # type: ignore[no-untyped-call]
 @xr.register_dataset_accessor("ggcm")  # type: ignore[no-untyped-call]
 class OpenGGCMAccessor:
+    """
+    XArray accessor to add OpenGGCM-specific features
+
+    As of now, that is ds.ggcm.coords which provides mlts and colats.
+    """
+
     def __init__(self, xarray_obj: Any):
         self._obj = xarray_obj
         self._coords: xr.Coordinates = self._obj.coords

--- a/src/ggcmpy/openggcm.py
+++ b/src/ggcmpy/openggcm.py
@@ -131,6 +131,7 @@ def _dt64_to_time_array(times: ArrayLike, dtype: DTypeLike) -> ArrayLike:
     ).T
 
 
+@xr.register_dataarray_accessor("ggcm")  # type: ignore[no-untyped-call]
 @xr.register_dataset_accessor("ggcm")  # type: ignore[no-untyped-call]
 class OpenGGCMAccessor:
     def __init__(self, xarray_obj: Any):

--- a/tests/test_openggcm.py
+++ b/tests/test_openggcm.py
@@ -72,3 +72,12 @@ def test_encode_decode_openggcm():
     ds_dt64 = xr.Dataset({"time": (("time"), sample_datetime64)})
     ds_decoded = openggcm.decode_openggcm(ds)
     assert ds_decoded.equals(ds_dt64)
+
+
+def test_coords():
+    ds = xr.Dataset(
+        {"longs": np.linspace(-180, 180, 61)}, {"lats": np.linspace(90, -90, 181)}
+    )
+    ds = openggcm.decode_openggcm(ds)
+    assert np.allclose(ds.mlts, np.linspace(0, 24, 61))
+    assert np.allclose(ds.colats, np.linspace(0, 180, 181))

--- a/tests/test_openggcm.py
+++ b/tests/test_openggcm.py
@@ -79,5 +79,5 @@ def test_coords():
         {"longs": np.linspace(-180, 180, 61)}, {"lats": np.linspace(90, -90, 181)}
     )
     ds = openggcm.decode_openggcm(ds)
-    assert np.allclose(ds.mlts, np.linspace(0, 24, 61))
-    assert np.allclose(ds.colats, np.linspace(0, 180, 181))
+    assert np.allclose(ds.ggcm.coords["mlts"], np.linspace(0, 24, 61))
+    assert np.allclose(ds.ggcm.coords["colats"], np.linspace(0, 180, 181))

--- a/tests/test_openggcm.py
+++ b/tests/test_openggcm.py
@@ -81,3 +81,5 @@ def test_coords():
     ds = openggcm.decode_openggcm(ds)
     assert np.allclose(ds.ggcm.coords["mlts"], np.linspace(0, 24, 61))
     assert np.allclose(ds.ggcm.coords["colats"], np.linspace(0, 180, 181))
+    assert np.allclose(ds.ggcm.mlts, np.linspace(0, 24, 61))
+    assert np.allclose(ds.ggcm.colats, np.linspace(0, 180, 181))


### PR DESCRIPTION
This accessor allows to get additional coordinates (specifically, mlts and colats) through, e.g., `ds.ggcm.coords["mlts"]`, or more succinctly, `ds.ggcm.mlts`.