### PR TITLE
en/decoding update (AmieTimeArrayCoder)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
         additional_dependencies:
           - pytest
           - xarray
-          - numpy
+          - xarray-adios2
           - pandas-stubs
 
   - repo: https://github.com/codespell-project/codespell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,9 @@ dynamic = ["version"]
 dependencies = ["numpy", "xarray", "typing-extensions", "dask"]
 
 [project.optional-dependencies]
-test = ["pytest >=6", "pytest-cov >=3"]
-dev = ["pytest >=6", "pytest-cov >=3"]
+test = ["pytest >=6", "pytest-cov >=3", "xarray-adios2"]
+dev = ["pytest >=6", "pytest-cov >=3", "xarray-adios2"]
+adios2 = ["xarray-adios2"]
 docs = [
   "sphinx>=7.0",
   "myst_parser>=0.13",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = ["numpy", "xarray", "typing-extensions", "dask"]
 
 [project.optional-dependencies]
 test = ["pytest >=6", "pytest-cov >=3", "xarray-adios2"]
-dev = ["pytest >=6", "pytest-cov >=3", "xarray-adios2"]
+dev = ["pytest >=6", "pytest-cov >=3", "xarray-adios2", "nox"]
 adios2 = ["xarray-adios2"]
 docs = [
   "sphinx>=7.0",

--- a/src/ggcmpy/openggcm.py
+++ b/src/ggcmpy/openggcm.py
@@ -6,6 +6,7 @@ from collections.abc import Hashable, Iterable, Mapping, Sequence
 from itertools import islice
 from pathlib import Path
 from typing import Any
+from warnings import warn
 
 import numpy as np
 import pandas as pd
@@ -49,6 +50,12 @@ def parse_timestring(timestr: str) -> dict[str, Any]:
 
 
 def decode_openggcm(ds: xr.Dataset) -> xr.Dataset:
+    warn(
+        "decode_openggcm() is deprecated. Pass 'decode_times=openggcm.AmieTimeArrayDecoder()' "
+        "to open_dataset() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     coder = AmieTimeArrayCoder()
     for name, var in ds.variables.items():
         ds[name] = coder.decode(var, name)

--- a/src/ggcmpy/openggcm.py
+++ b/src/ggcmpy/openggcm.py
@@ -73,6 +73,19 @@ def encode_openggcm(
 
 
 class AmieTimeArrayCoder(CFDatetimeCoder):
+    """
+    A custom coder for encoding and decoding time arrays in xarray Variables.
+    This class extends the CFDatetimeCoder to handle variables with a custom
+    "time_array" encoding, and otherwise falls back to the usual CF coding/encoding.
+
+    Methods
+    -------
+    encode(variable: xr.Variable, name: Hashable | None = None) -> xr.Variable
+        Encodes an xarray Variable with a "time_array" unit into a custom format.
+    decode(variable: xr.Variable, name: Hashable | None = None) -> xr.Variable
+        Decodes an xarray Variable with a "time_array" unit from a custom format.
+    """
+
     def __init__(self, use_cftime: bool | None = None):
         super().__init__(use_cftime=use_cftime)
 

--- a/tests/test_openggcm.py
+++ b/tests/test_openggcm.py
@@ -31,7 +31,7 @@ def test_to_time_array():
         (("time_array",), sample_time_array[0], sample_datetime64[0]),
     ],
 )
-def test_decode_openggcm_variable(dims, data_time_array, data_datetime64):
+def test_AmieTimeArrayCoder(dims, data_time_array, data_datetime64):
     var = xr.Variable(dims, data_time_array)
     var_dt64 = xr.Variable(dims[:-1], data_datetime64)
 
@@ -66,19 +66,10 @@ def test_encode_openggcm_variable(dims, data_time_array, data_datetime64):
     assert encoded_var.encoding == {}
 
 
-def test_encode_decode_openggcm():
-    ds = xr.Dataset({"time": (("time", "time_array"), sample_time_array)})
-    ds["time"].attrs["units"] = "time_array"
-    ds_dt64 = xr.Dataset({"time": (("time"), sample_datetime64)})
-    ds_decoded = openggcm.decode_openggcm(ds)
-    assert ds_decoded.equals(ds_dt64)
-
-
 def test_coords():
     ds = xr.Dataset(
         {"longs": np.linspace(-180, 180, 61)}, {"lats": np.linspace(90, -90, 181)}
     )
-    ds = openggcm.decode_openggcm(ds)
     assert np.allclose(ds.ggcm.coords["mlts"], np.linspace(0, 24, 61))
     assert np.allclose(ds.ggcm.coords["colats"], np.linspace(0, 180, 181))
     assert np.allclose(ds.ggcm.mlts, np.linspace(0, 24, 61))

--- a/tests/test_openggcm.py
+++ b/tests/test_openggcm.py
@@ -35,11 +35,12 @@ def test_decode_openggcm_variable(dims, data_time_array, data_datetime64):
     var = xr.Variable(dims, data_time_array)
     var_dt64 = xr.Variable(dims[:-1], data_datetime64)
 
-    decoded_var = openggcm._decode_openggcm_variable(var, "name")
+    coder = openggcm.AmieTimeArrayCoder()
+    decoded_var = coder.decode(var, "name")
     assert decoded_var.equals(var)  # type: ignore[no-untyped-call]
 
     var.attrs["units"] = "time_array"
-    decoded_var = openggcm._decode_openggcm_variable(var, "name")
+    decoded_var = coder.decode(var, "name")
     assert decoded_var.equals(var_dt64)  # type: ignore[no-untyped-call]
     assert var.attrs == {"units": "time_array"}  # original var not changed
     assert decoded_var.encoding == {"units": "time_array", "dtype": var.dtype}
@@ -56,12 +57,13 @@ def test_encode_openggcm_variable(dims, data_time_array, data_datetime64):
     var = xr.Variable(dims, data_time_array)
     var_dt64 = xr.Variable(dims[:-1], data_datetime64)
 
-    encoded_var = openggcm._encode_openggcm_variable(var_dt64)
+    coder = openggcm.AmieTimeArrayCoder()
+    encoded_var = coder.encode(var_dt64)
     assert encoded_var.equals(var_dt64)  # type: ignore[no-untyped-call]
 
     var.attrs["units"] = "time_array"
-    decoded_var = openggcm._decode_openggcm_variable(var, "name")
-    encoded_var = openggcm._encode_openggcm_variable(decoded_var)
+    decoded_var = coder.decode(var, "name")
+    encoded_var = coder.encode(decoded_var)
     assert encoded_var.equals(var)  # type: ignore[no-untyped-call]
     assert encoded_var.encoding == {}
 

--- a/tests/test_openggcm.py
+++ b/tests/test_openggcm.py
@@ -49,20 +49,18 @@ def test_decode_openggcm_variable(dims, data_time_array, data_datetime64):
 @pytest.mark.parametrize(
     ("dims", "data_time_array", "data_datetime64"),
     [
-        (("time", "time_array"), sample_time_array, sample_datetime64),
-        (("time_array",), sample_time_array[0], sample_datetime64[0]),
+        (("time", "time_array"), sample_time_array, sample_datetime64),  # time array
+        (("time_array",), sample_time_array[0], sample_datetime64[0]),  # scalar time
     ],
 )
 def test_encode_openggcm_variable(dims, data_time_array, data_datetime64):
     var = xr.Variable(dims, data_time_array)
     var_dt64 = xr.Variable(dims[:-1], data_datetime64)
 
-    coder = openggcm.AmieTimeArrayCoder()
-    encoded_var = coder.encode(var_dt64)
-    assert encoded_var.equals(var_dt64)  # type: ignore[no-untyped-call]
-
     var.attrs["units"] = "time_array"
+    coder = openggcm.AmieTimeArrayCoder()
     decoded_var = coder.decode(var, "name")
+    assert decoded_var.equals(var_dt64)  # type: ignore[no-untyped-call]
     encoded_var = coder.encode(decoded_var)
     assert encoded_var.equals(var)  # type: ignore[no-untyped-call]
     assert encoded_var.encoding == {}

--- a/tests/test_xarray_openggcm.py
+++ b/tests/test_xarray_openggcm.py
@@ -82,9 +82,8 @@ def test_time_write_read_by_step(tmp_path, time_dataset):
     time_dataset.dump_to_store(
         Adios2Store.open(filename, "w"), encoder=openggcm.encode_openggcm
     )
-    ds = xr.open_dataset(filename)
+    ds = xr.open_dataset(filename, decode_times=openggcm.AmieTimeArrayCoder())
     # FIXME, should mark time_scalar as invariant, so it doesn't get read back twice
-    ds = openggcm.decode_openggcm(ds)
     ds["time_scalar"] = ds.time_scalar.isel(time=0)
     assert time_dataset.equals(ds)
 
@@ -96,6 +95,7 @@ def test_time_write_read_one_step(tmp_path, time_dataset):
     )
     with adios2py.File(filename, "r") as file:
         for step in file.steps:
-            ds_read = xr.open_dataset(Adios2Store(step))
-            ds_read = openggcm.decode_openggcm(ds_read)
+            ds_read = xr.open_dataset(
+                Adios2Store(step), decode_times=openggcm.AmieTimeArrayCoder()
+            )
             assert time_dataset.equals(ds_read)


### PR DESCRIPTION
This deprecates `decode_openggcm` and instead introduces AmieTimeArrayCoder, that can be passed to
`open_dataset(..., decode_times=AmieTimeArrayCoder()`. 

It'd be even better to get of it it altogether, ie., have GITM
understand time in a CF native format -- maybe we'll get there eventually.