### PR TITLE
ggcmpy: Don't keep "time" attribute on each field

### DIFF
--- a/src/ggcmpy/jrrle_store.py
+++ b/src/ggcmpy/jrrle_store.py
@@ -261,6 +261,8 @@ class JrrleStore(AbstractDataStore):
         fld_info: Mapping[str, Any],
     ) -> Variable:
         attrs = dict(fld_info)
+        attrs.pop("time", None)
+
         data = indexing.LazilyIndexedArray(JrrleArray(name, self, fld_info))
         encoding: dict[str, Any] = {}
 


### PR DESCRIPTION
"time" is already there as a coordinate, and
datetime64 attributes can't be written to adios2