### PR TITLE
pin xarray<2025.07

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
         args: []
         additional_dependencies:
           - pytest
-          - xarray
+          - xarray<2025.07
           - xarray-adios2
           - pandas-stubs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 # dask is currently required because open_mfdataset() otherwise fails
-dependencies = ["xarray", "typing-extensions", "dask", "matplotlib"]
+dependencies = ["xarray<2025.07", "typing-extensions", "dask", "matplotlib"]
 
 [project.optional-dependencies]
 test = ["pytest >=6", "pytest-cov >=3", "xarray-adios2", "matplotlib"]


### PR DESCRIPTION
Latest xarray drops Python 3.10 support and has other incompatible internal changes.