### PR TITLE
fix: extract the single datetime value first

### DIFF
--- a/src/ggcmpy/timeseries.py
+++ b/src/ggcmpy/timeseries.py
@@ -125,7 +125,8 @@ def read_ggcm_solarwind_directory(directory: pathlib.Path, glob: str = "*"):
 def write_ggcm_solarwind_file(filename: pathlib.Path, field: xr.DataArray):
     with filename.open("w") as f:
         for v in field:
-            st = v.time.dt.strftime("%Y %m %d %H %M %S.%f").item()
+            # st = v.time.dt.strftime("%Y %m %d %H %M %S.%f").item()
+            st = pd.Timestamp(v.time.values).strftime("%Y %m %d %H %M %S.%f")
             f.write(f"{st} {float(v)}\n")
 
 

--- a/src/ggcmpy/timeseries.py
+++ b/src/ggcmpy/timeseries.py
@@ -125,7 +125,6 @@ def read_ggcm_solarwind_directory(directory: pathlib.Path, glob: str = "*"):
 def write_ggcm_solarwind_file(filename: pathlib.Path, field: xr.DataArray):
     with filename.open("w") as f:
         for v in field:
-            # st = v.time.dt.strftime("%Y %m %d %H %M %S.%f").item()
             st = pd.Timestamp(v.time.values).strftime("%Y %m %d %H %M %S.%f")
             f.write(f"{st} {float(v)}\n")
 


### PR DESCRIPTION
A crash happens when running `CDAWebRunInput.py`.

The line causing the crash is,
```
st = v.time.dt.strftime("%Y %m %d %H %M %S.%f").item()
```

Rather than asking `xarray` to format the whole array object and then extracting the item, the fix is to extract the single datetime value first, and then format it.