### PR TITLE
Introduce ABC emfields and C++ emfields_dipole

### DIFF
--- a/src/ggcmpy/libopenggcm/include/openggcm/constants.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/constants.hxx
@@ -1,0 +1,18 @@
+
+#pragma once
+
+#include <numbers>
+
+namespace openggcm
+{
+namespace constants
+{
+
+constexpr double pi = std::numbers::pi;
+constexpr double c = 299792458.0;       // speed of light in m/s
+constexpr double e = 1.602176634e-19;   // elementary charge in C
+constexpr double m_e = 9.10938356e-31;  // electron mass in kg
+constexpr double mu0 = 4.0 * pi * 1e-7; // vacuum permeability
+
+} // namespace constants
+} // namespace openggcm

--- a/src/ggcmpy/libopenggcm/include/openggcm/emfields.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/emfields.hxx
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include <openggcm/constants.hxx>
 #include <openggcm/util.hxx>
 
 #include <string>
@@ -37,6 +38,30 @@ public:
 private:
   double3 _E_0;
   double3 _B_0;
+};
+
+class emfields_dipole : public emfields
+{
+public:
+  emfields_dipole(double3 m) : m_(m) {}
+
+  double3 E(double3 r) const override { return {}; }
+  double3 B(double3 r) const override
+  {
+    double rnorm = norm(r);
+    double3 rhat = r / rnorm;
+    return constants::mu0 / (4.0 * constants::pi) *
+           (3.0 * dot(m_, rhat) * rhat - m_) / std::pow(rnorm, 3);
+  }
+
+  std::string repr() const override
+  {
+    return "emfields_dipole(m=[" + std::to_string(m_[0]) + ", " +
+           std::to_string(m_[1]) + ", " + std::to_string(m_[2]) + "])";
+  }
+
+private:
+  double3 m_; // magnetic moment
 };
 
 } // namespace openggcm

--- a/src/ggcmpy/libopenggcm/include/openggcm/emfields.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/emfields.hxx
@@ -8,15 +8,25 @@
 namespace openggcm
 {
 
-class emfields_uniform
+class emfields
+{
+public:
+  virtual ~emfields() = default;
+
+  virtual double3 E(double3 r) const = 0;
+  virtual double3 B(double3 r) const = 0;
+  virtual std::string repr() const = 0;
+};
+
+class emfields_uniform : public emfields
 {
 public:
   emfields_uniform(double3 E_0, double3 B_0) : _E_0(E_0), _B_0(B_0) {}
 
-  double3 E(double3 r) const { return _E_0; }
-  double3 B(double3 r) const { return _B_0; }
+  double3 E(double3 r) const override { return _E_0; }
+  double3 B(double3 r) const override { return _B_0; }
 
-  std::string repr() const
+  std::string repr() const override
   {
     return "emfields_uniform(E_0=[" + std::to_string(_E_0[0]) + ", " +
            std::to_string(_E_0[1]) + ", " + std::to_string(_E_0[2]) +

--- a/src/ggcmpy/libopenggcm/include/openggcm/util.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/util.hxx
@@ -8,4 +8,16 @@ namespace openggcm
 
 using double3 = xt::xtensor_fixed<double, xt::xshape<3>>;
 
+inline double sqr(double x) { return x * x; }
+
+inline double norm(double3 x)
+{
+  return std::sqrt(sqr(x[0]) + sqr(x[1]) + sqr(x[2]));
 }
+
+inline double dot(double3 x, double3 y)
+{
+  return x[0] * y[0] + x[1] * y[1] + x[2] * y[2];
+}
+
+} // namespace openggcm

--- a/src/ggcmpy/libopenggcm/include/openggcm/util.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/util.hxx
@@ -3,4 +3,9 @@
 
 #include <xtensor/containers/xfixed.hpp>
 
+namespace openggcm
+{
+
 using double3 = xt::xtensor_fixed<double, xt::xshape<3>>;
+
+}

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -28,9 +28,12 @@ NB_MODULE(_openggcm, m)
   m.def("xt_fixed_from_python",
         [](xt::xtensor_fixed<double, xt::xshape<3>> a) { return a; });
 
-  nb::class_<openggcm::emfields_uniform>(m, "emfields_uniform")
-      .def(nb::init<double3, double3>(), "E_0"_a, "B_0"_a)
-      .def("E", &openggcm::emfields_uniform::E, "r"_a)
-      .def("B", &openggcm::emfields_uniform::B, "r"_a)
-      .def("__repr__", &openggcm::emfields_uniform::repr);
+  nb::class_<openggcm::emfields>(m, "emfields")
+      .def("E", &openggcm::emfields::E, "r"_a)
+      .def("B", &openggcm::emfields::B, "r"_a)
+      .def("__repr__", &openggcm::emfields::repr);
+
+  nb::class_<openggcm::emfields_uniform, openggcm::emfields>(m,
+                                                             "emfields_uniform")
+      .def(nb::init<double3, double3>(), "E_0"_a, "B_0"_a);
 }

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -36,4 +36,7 @@ NB_MODULE(_openggcm, m)
 
   nb::class_<emfields_uniform, emfields>(m, "emfields_uniform")
       .def(nb::init<double3, double3>(), "E_0"_a, "B_0"_a);
+
+  nb::class_<emfields_dipole, emfields>(m, "emfields_dipole")
+      .def(nb::init<double3>(), "m"_a);
 }

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -22,18 +22,18 @@ NAMESPACE_END(NB_NAMESPACE)
 
 namespace nb = nanobind;
 using namespace nb::literals;
+using namespace openggcm;
 
 NB_MODULE(_openggcm, m)
 {
   m.def("xt_fixed_from_python",
         [](xt::xtensor_fixed<double, xt::xshape<3>> a) { return a; });
 
-  nb::class_<openggcm::emfields>(m, "emfields")
-      .def("E", &openggcm::emfields::E, "r"_a)
-      .def("B", &openggcm::emfields::B, "r"_a)
-      .def("__repr__", &openggcm::emfields::repr);
+  nb::class_<emfields>(m, "emfields")
+      .def("E", &emfields::E, "r"_a)
+      .def("B", &emfields::B, "r"_a)
+      .def("__repr__", &emfields::repr);
 
-  nb::class_<openggcm::emfields_uniform, openggcm::emfields>(m,
-                                                             "emfields_uniform")
+  nb::class_<emfields_uniform, emfields>(m, "emfields_uniform")
       .def(nb::init<double3, double3>(), "E_0"_a, "B_0"_a);
 }

--- a/src/ggcmpy/libopenggcm/tests/test_emfields.cxx
+++ b/src/ggcmpy/libopenggcm/tests/test_emfields.cxx
@@ -3,11 +3,13 @@
 
 #include <openggcm/emfields.hxx>
 
+using namespace openggcm;
+
 TEST(EmfieldsTest, ConstantFields)
 {
   double3 E_0 = {1.0, 2.0, 3.0};
   double3 B_0 = {4.0, 5.0, 6.0};
-  openggcm::emfields_uniform fields(E_0, B_0);
+  emfields_uniform fields(E_0, B_0);
 
   EXPECT_EQ(fields.E({0.0, 0.0, 0.0}), E_0);
   EXPECT_EQ(fields.B({0.0, 0.0, 0.0}), B_0);

--- a/src/ggcmpy/tracing/emfields.py
+++ b/src/ggcmpy/tracing/emfields.py
@@ -68,6 +68,9 @@ class dipole_python:
         return np.array([0.0, 0.0, 0.0])
 
 
+dipole_cxx = _openggcm.emfields_dipole
+
+
 class interpolator_python:
     """
     A class for interpolating electromagnetic field components from a xarray.Dataset.

--- a/tests/test_emfields.py
+++ b/tests/test_emfields.py
@@ -7,7 +7,7 @@ import xarray as xr
 from numpy.typing import ArrayLike
 
 import ggcmpy.constants
-from ggcmpy import tracing
+import ggcmpy.tracing
 
 R_E = ggcmpy.constants.radius_earth
 m_E = ggcmpy.constants.dipole_moment_earth
@@ -73,8 +73,15 @@ def test_emfields_uniform(emfields_uniform):
     assert np.allclose(emfields.B(pos), [4.0, 5.0, 6.0])
 
 
-def test_emfields_dipole():
-    emfields = tracing.emfields.dipole(m=m_E)
+@pytest.mark.parametrize(
+    "emfields_dipole",
+    [
+        ggcmpy.tracing.emfields.dipole_python,
+        ggcmpy.tracing.emfields.dipole_cxx,
+    ],
+)
+def test_emfields_dipole(emfields_dipole):
+    emfields = emfields_dipole(m=m_E)
     r = np.array([R_E, 0.0, 0.0])
     r_hat = r / np.linalg.norm(r)
     B_expected = (


### PR DESCRIPTION
This pull request introduces a new C++ implementation of a magnetic dipole field, refactors the electromagnetic field class hierarchy, and integrates these changes into both the C++ and Python interfaces. The main improvements are the addition of a reusable constants module, the introduction of a base `emfields` class, and support for testing both Python and C++ dipole field implementations.

Core library enhancements:

* Added a new `constants.hxx` header providing fundamental physical constants (e.g., π, μ₀, speed of light, elementary charge, electron mass) for use throughout the codebase.
* Introduced a base abstract class `emfields` with virtual methods for electric and magnetic fields, and refactored `emfields_uniform` to inherit from it.
* Added a new `emfields_dipole` class implementing the magnetic dipole field using the new constants and utility functions.
* Added utility functions for vector operations (`norm`, `dot`, `sqr`) in `util.hxx` to simplify field calculations.

Python bindings and testing:

* Extended nanobind bindings to expose the new `emfields` hierarchy and the `emfields_dipole` class to Python, enabling polymorphic field access.
* Added `dipole_cxx` to the Python interface for direct use of the C++ dipole implementation, and updated tests to parameterize over both Python and C++ dipole field implementations. [[1]](diffhunk://#diff-04298adb77ac6413c9c95289f4168137c67b81aeae08c9bda304e162fcbd3513R71-R73) [[2]](diffhunk://#diff-5c07dfa6cb64d2066c4c8962169d93d36ae9516deccdc707571f790ac5194bf5L76-R84)
* Minor code cleanups and import fixes in test modules. [[1]](diffhunk://#diff-5c07dfa6cb64d2066c4c8962169d93d36ae9516deccdc707571f790ac5194bf5L10-R10) [[2]](diffhunk://#diff-65bb0d145a6e23d4b6b4a54a31928667fbdfcf9286a8fe1e089761b93c399cefR6-R12)