### PR TITLE
Add tests and support for nb::ndarray lifetime and layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,12 @@ dynamic = ["version"]
 dependencies = ["xarray<2025.07", "numpy<2.5", "typing-extensions", "dask", "matplotlib", "scipy", "nanobind"]
 
 [project.optional-dependencies]
-test = ["pytest >=6", "pytest-cov >=3", "xarray-adios2", "cartopy"]
+test = ["pytest >=6", "pytest-cov >=3", "xarray-adios2", "cartopy", "pyspedas"]
 dev = [
   "pytest >=6",
   "pytest-cov >=3",
   "xarray-adios2",
+  "cartopy",
   "pyspedas",
   "nox[uv]",
   "pre-commit",

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -11,12 +11,12 @@
 #include <xtensor/containers/xfixed.hpp>
 
 template <typename T>
-using nb_array_type = nanobind::ndarray<T, nanobind::any_contig>;
+using nb_ndarray_type = nanobind::ndarray<T, nanobind::any_contig>;
 
 namespace detail
 {
 template <typename T>
-std::vector<std::size_t> shape_from_nb(const nb_array_type<T> &a)
+std::vector<std::size_t> shape_from_nb(const nb_ndarray_type<T> &a)
 {
   std::vector<std::size_t> shape(a.ndim());
   for (std::size_t i = 0; i < a.ndim(); ++i)
@@ -26,7 +26,8 @@ std::vector<std::size_t> shape_from_nb(const nb_array_type<T> &a)
   return shape;
 }
 
-template <typename T> xt::layout_type layout_from_nb(const nb_array_type<T> &a)
+template <typename T>
+xt::layout_type layout_from_nb(const nb_ndarray_type<T> &a)
 {
   size_t ndim = a.ndim();
 
@@ -75,21 +76,21 @@ template <typename T> xt::layout_type layout_from_nb(const nb_array_type<T> &a)
 
 } // namespace detail
 
-template <typename T> auto xt_adapt_ndarray(nb_array_type<T> arr)
+template <typename T> auto xt_adapt_ndarray(nb_ndarray_type<T> arr)
 {
   return xt::adapt_smart_ptr<xt::layout_type::dynamic>(
       arr.data(), detail::shape_from_nb(arr),
-      std::make_unique<nb_array_type<T>>(arr), detail::layout_from_nb(arr));
+      std::make_unique<nb_ndarray_type<T>>(arr), detail::layout_from_nb(arr));
 }
 
 // template <typename T>
 // using xt_ndarray =
-//   decltype(xt_adapt_ndarray(std::declval<nb_array_type<T>>()));
+//   decltype(xt_adapt_ndarray(std::declval<nb_ndarray_type<T>>()));
 
 template <typename T>
 using xt_ndarray =
     xt::xarray_adaptor<xt::xbuffer_adaptor<T *, xt::smart_ownership,
-                                           std::unique_ptr<nb_array_type<T>>>,
+                                           std::unique_ptr<nb_ndarray_type<T>>>,
                        xt::layout_type::dynamic, std::vector<std::size_t>>;
 
 NAMESPACE_BEGIN(NB_NAMESPACE)
@@ -101,11 +102,41 @@ struct type_caster<xt::xtensor_fixed<Type, xt::xshape<Size>>>
 {
 };
 
-template <typename T> struct type_caster<xt_ndarray<T>>
+template <typename T> struct type_caster<xt::xarray<T>>
 {
   NB_TYPE_CASTER(xt::xarray<T>,
-                 const_name("xt_ndarray<") + const_name<T>() + const_name(">"));
+                 const_name("xt::xarray<") + const_name<T>() + const_name(">"));
+
+  bool from_python(handle src, uint8_t flags, cleanup_list *cleanup) noexcept
+  {
+    auto ndarray_caster = make_caster<nb_ndarray_type<T>>();
+    if (!ndarray_caster.from_python(src, flags, cleanup))
+    {
+      return false;
+    }
+
+    value = xt_adapt_ndarray(ndarray_caster.value);
+    return true;
+  };
 };
+
+// template <typename T>
+// struct type_caster<xt_ndarray<T>>
+// {
+//   NB_TYPE_CASTER(xt_ndarray<T>, const_name("xt_ndarray<") + const_name<T>() +
+//                                   const_name(">&&"));
+
+//   bool from_python(handle src, uint8_t flags, cleanup_list* cleanup) noexcept
+//   {
+//     auto ndarray_caster = make_caster<nb_ndarray_type<T>>();
+//     if (!ndarray_caster.from_python(src, flags, cleanup)) {
+//       return false;
+//     }
+
+//     value = xt_adapt_ndarray(ndarray_caster.value);
+//     return true;
+//   };
+// };
 
 NAMESPACE_END(detail)
 NAMESPACE_END(NB_NAMESPACE)
@@ -130,7 +161,7 @@ private:
 class test_xtadapt
 {
 public:
-  test_xtadapt(nb_array_type<double> a) : a_xt_(xt_adapt_ndarray(a)) {}
+  test_xtadapt(nb_ndarray_type<double> a) : a_xt_(xt_adapt_ndarray(a)) {}
 
   double operator()(std::size_t i) const { return a_xt_(i); }
   double operator()(std::size_t i, std::size_t j) const { return a_xt_(i, j); }
@@ -161,14 +192,32 @@ NB_MODULE(_openggcm, m)
   m.def("xt_fixed_from_python",
         [](xt::xtensor_fixed<double, xt::xshape<3>> a) { return a; });
 
-  // m.def("xt_adaptor_type_from_python", [](xt_adaptor_type a) {});
+  m.def("xt_array_from_python",
+        [](xt::xarray<double> a)
+        {
+          return "xt::array ndim=" + std::to_string(a.dimension());
+          a(1) = 99.;
+        });
+
+  m.def("xt_ndarray_from_python_manual",
+        [](nb_ndarray_type<double> a)
+        {
+          auto a_xt = xt_adapt_ndarray(a);
+          a_xt(1) = 99.;
+          return "xt_ndarray ndim=" + std::to_string(a_xt.dimension());
+        });
+
+  // m.def("xt_ndarray_from_python", [](xt_ndarray<double>&& a) {
+  //   a(1) = 99.;
+  //   return "xt_ndarray ndim=" + std::to_string(a.dimension());
+  // });
 
   nb::class_<test::test_ndarray>(m, "test_ndarray")
       .def(nb::init<nb::ndarray<double, nb::ndim<1>>>())
       .def("__getitem__", &test::test_ndarray::operator[], "i"_a);
 
   nb::class_<test::test_xtadapt>(m, "test_xtadapt")
-      .def(nb::init<nb_array_type<double>>(), nb::arg().noconvert())
+      .def(nb::init<nb_ndarray_type<double>>(), nb::arg().noconvert())
       .def("__getitem__",
            [](test::test_xtadapt &self, std::size_t i) { return self(i); })
       .def("__getitem__",

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -36,6 +36,20 @@ public:
 private:
   nb::ndarray<double, nb::ndim<1>> arr_;
 };
+
+class test_xtadapt
+{
+public:
+  test_xtadapt(nb::ndarray<double, nb::ndim<1>> a)
+      : a_(std::make_unique<nb::ndarray<double, nb::ndim<1>>>(a))
+  {
+  }
+
+  double operator[](std::size_t i) const { return a_.get()->operator()(i); }
+
+private:
+  std::unique_ptr<nb::ndarray<double, nb::ndim<1>>> a_;
+};
 } // namespace test
 
 NB_MODULE(_openggcm, m)
@@ -46,6 +60,10 @@ NB_MODULE(_openggcm, m)
   nb::class_<test::test_ndarray>(m, "test_ndarray")
       .def(nb::init<nb::ndarray<double, nb::ndim<1>>>())
       .def("__getitem__", &test::test_ndarray::operator[], "i"_a);
+
+  nb::class_<test::test_xtadapt>(m, "test_xtadapt")
+      .def(nb::init<nb::ndarray<double, nb::ndim<1>>>())
+      .def("__getitem__", &test::test_xtadapt::operator[], "i"_a);
 
   nb::class_<emfields>(m, "emfields")
       .def("E", &emfields::E, "r"_a)

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -2,10 +2,12 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/string.h>
+#include <nanobind/stl/tuple.h>
 
 #include <openggcm/emfields.hxx>
 
 #include <nanobind/stl/detail/nb_array.h>
+#include <xtensor/containers/xadapt.hpp>
 #include <xtensor/containers/xfixed.hpp>
 
 NAMESPACE_BEGIN(NB_NAMESPACE)
@@ -39,16 +41,49 @@ private:
 
 class test_xtadapt
 {
+  using nb_array_type = nb::ndarray<double, nb::c_contig>;
+  using xt_adapter_type = decltype(xt::adapt_smart_ptr(
+      std::declval<double *>(), std::declval<std::vector<std::size_t>>(),
+      std::declval<std::unique_ptr<nb_array_type>>()));
+
+  std::vector<std::size_t> make_shape(const nb_array_type &a)
+  {
+    std::vector<std::size_t> shape(a.ndim());
+    for (std::size_t i = 0; i < a.ndim(); ++i)
+    {
+      shape[i] = a.shape(i);
+    }
+    return shape;
+  }
+
 public:
-  test_xtadapt(nb::ndarray<double, nb::ndim<1>> a)
-      : a_(std::make_unique<nb::ndarray<double, nb::ndim<1>>>(a))
+  test_xtadapt(nb_array_type a)
+      : a_xt_(std::move(xt::adapt_smart_ptr(
+            a.data(), make_shape(a), std::make_unique<nb_array_type>(a))))
   {
   }
 
-  double operator[](std::size_t i) const { return a_.get()->operator()(i); }
+  double operator()(std::size_t i) const { return a_xt_(i); }
+  double operator()(std::size_t i, std::size_t j) const { return a_xt_(i, j); }
+
+  std::string repr() const
+  {
+    std::string rv = "test_xtadapt(shape=[";
+    auto shape = a_xt_.shape();
+    for (std::size_t i = 0; i < shape.size(); ++i)
+    {
+      rv += std::to_string(shape[i]);
+      if (i < shape.size() - 1)
+      {
+        rv += ", ";
+      }
+    }
+    rv += "])";
+    return rv;
+  }
 
 private:
-  std::unique_ptr<nb::ndarray<double, nb::ndim<1>>> a_;
+  xt_adapter_type a_xt_;
 };
 } // namespace test
 
@@ -62,8 +97,16 @@ NB_MODULE(_openggcm, m)
       .def("__getitem__", &test::test_ndarray::operator[], "i"_a);
 
   nb::class_<test::test_xtadapt>(m, "test_xtadapt")
-      .def(nb::init<nb::ndarray<double, nb::ndim<1>>>())
-      .def("__getitem__", &test::test_xtadapt::operator[], "i"_a);
+      .def(nb::init<nb::ndarray<double, nb::c_contig>>(), nb::arg().noconvert())
+      .def("__getitem__",
+           [](test::test_xtadapt &self, std::size_t i) { return self(i); })
+      .def("__getitem__",
+           [](test::test_xtadapt &self, std::tuple<std::size_t> idx)
+           { return self(std::get<0>(idx)); })
+      .def("__getitem__", [](test::test_xtadapt &self,
+                             std::tuple<std::size_t, std::size_t> idx)
+           { return self(std::get<0>(idx), std::get<1>(idx)); })
+      .def("__repr__", &test::test_xtadapt::repr);
 
   nb::class_<emfields>(m, "emfields")
       .def("E", &emfields::E, "r"_a)

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -41,25 +41,17 @@ private:
 
 class test_xtadapt
 {
-  using nb_array_type = nb::ndarray<double, nb::c_contig>;
-  using xt_adapter_type = decltype(xt::adapt_smart_ptr(
-      std::declval<double *>(), std::declval<std::vector<std::size_t>>(),
-      std::declval<std::unique_ptr<nb_array_type>>()));
-
-  std::vector<std::size_t> make_shape(const nb_array_type &a)
-  {
-    std::vector<std::size_t> shape(a.ndim());
-    for (std::size_t i = 0; i < a.ndim(); ++i)
-    {
-      shape[i] = a.shape(i);
-    }
-    return shape;
-  }
-
 public:
+  using nb_array_type = nb::ndarray<double, nb::any_contig>;
+  using xt_adapter_type =
+      decltype(xt::adapt_smart_ptr<xt::layout_type::dynamic>(
+          std::declval<double *>(), std::declval<std::vector<std::size_t>>(),
+          std::declval<std::unique_ptr<nb_array_type>>()));
+
   test_xtadapt(nb_array_type a)
-      : a_xt_(std::move(xt::adapt_smart_ptr(
-            a.data(), make_shape(a), std::make_unique<nb_array_type>(a))))
+      : a_xt_(xt::adapt_smart_ptr<xt::layout_type::dynamic>(
+            a.data(), shape_from_nb(a), std::make_unique<nb_array_type>(a),
+            layout_from_nb(a)))
   {
   }
 
@@ -83,6 +75,63 @@ public:
   }
 
 private:
+  std::vector<std::size_t> shape_from_nb(const nb_array_type &a)
+  {
+    std::vector<std::size_t> shape(a.ndim());
+    for (std::size_t i = 0; i < a.ndim(); ++i)
+    {
+      shape[i] = a.shape(i);
+    }
+    return shape;
+  }
+
+  xt::layout_type layout_from_nb(const nb_array_type &a)
+  {
+    size_t ndim = a.ndim();
+
+    // 0D or 1D arrays are contiguous in both definitions
+    if (ndim <= 1)
+    {
+      return xt::layout_type::row_major; // F as well...
+    }
+
+    // Expected stride for the next dimension
+    std::size_t expected_c_stride = 1;
+    std::size_t expected_f_stride = 1;
+
+    // Check C-Contiguous (Row-Major): Strides increase from right to left
+    bool is_c_contig = true;
+    for (int i = (int)ndim - 1; i >= 0; --i)
+    {
+      if (a.stride(i) != expected_c_stride)
+      {
+        is_c_contig = false;
+      }
+      expected_c_stride *= a.shape(i);
+    }
+    if (is_c_contig)
+    {
+      return xt::layout_type::row_major;
+    }
+
+    // Check F-Contiguous (Column-Major): Strides increase from left to right
+    bool is_f_contig = true;
+    for (size_t i = 0; i < ndim; ++i)
+    {
+      if (a.stride(i) != expected_f_stride)
+      {
+        is_f_contig = false;
+      }
+      expected_f_stride *= a.shape(i);
+    }
+    if (is_f_contig)
+    {
+      return xt::layout_type::column_major;
+    }
+
+    return xt::layout_type::any; // should never happen
+  }
+
   xt_adapter_type a_xt_;
 };
 } // namespace test
@@ -97,7 +146,7 @@ NB_MODULE(_openggcm, m)
       .def("__getitem__", &test::test_ndarray::operator[], "i"_a);
 
   nb::class_<test::test_xtadapt>(m, "test_xtadapt")
-      .def(nb::init<nb::ndarray<double, nb::c_contig>>(), nb::arg().noconvert())
+      .def(nb::init<test::test_xtadapt::nb_array_type>(), nb::arg().noconvert())
       .def("__getitem__",
            [](test::test_xtadapt &self, std::size_t i) { return self(i); })
       .def("__getitem__",

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -24,10 +24,28 @@ namespace nb = nanobind;
 using namespace nb::literals;
 using namespace openggcm;
 
+namespace test
+{
+class test_ndarray
+{
+public:
+  test_ndarray(nb::ndarray<double, nb::ndim<1>> arr) : arr_(arr) {}
+
+  double operator[](std::size_t i) const { return arr_(i); }
+
+private:
+  nb::ndarray<double, nb::ndim<1>> arr_;
+};
+} // namespace test
+
 NB_MODULE(_openggcm, m)
 {
   m.def("xt_fixed_from_python",
         [](xt::xtensor_fixed<double, xt::xshape<3>> a) { return a; });
+
+  nb::class_<test::test_ndarray>(m, "test_ndarray")
+      .def(nb::init<nb::ndarray<double, nb::ndim<1>>>())
+      .def("__getitem__", &test::test_ndarray::operator[], "i"_a);
 
   nb::class_<emfields>(m, "emfields")
       .def("E", &emfields::E, "r"_a)

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -10,6 +10,88 @@
 #include <xtensor/containers/xadapt.hpp>
 #include <xtensor/containers/xfixed.hpp>
 
+template <typename T>
+using nb_array_type = nanobind::ndarray<T, nanobind::any_contig>;
+
+namespace detail
+{
+template <typename T>
+std::vector<std::size_t> shape_from_nb(const nb_array_type<T> &a)
+{
+  std::vector<std::size_t> shape(a.ndim());
+  for (std::size_t i = 0; i < a.ndim(); ++i)
+  {
+    shape[i] = a.shape(i);
+  }
+  return shape;
+}
+
+template <typename T> xt::layout_type layout_from_nb(const nb_array_type<T> &a)
+{
+  size_t ndim = a.ndim();
+
+  // 0D or 1D arrays are contiguous in both definitions
+  if (ndim <= 1)
+  {
+    return xt::layout_type::row_major; // F as well...
+  }
+
+  // Expected stride for the next dimension
+  std::size_t expected_c_stride = 1;
+  std::size_t expected_f_stride = 1;
+
+  // Check C-Contiguous (Row-Major): Strides increase from right to left
+  bool is_c_contig = true;
+  for (int i = (int)ndim - 1; i >= 0; --i)
+  {
+    if (a.stride(i) != expected_c_stride)
+    {
+      is_c_contig = false;
+    }
+    expected_c_stride *= a.shape(i);
+  }
+  if (is_c_contig)
+  {
+    return xt::layout_type::row_major;
+  }
+
+  // Check F-Contiguous (Column-Major): Strides increase from left to right
+  bool is_f_contig = true;
+  for (size_t i = 0; i < ndim; ++i)
+  {
+    if (a.stride(i) != expected_f_stride)
+    {
+      is_f_contig = false;
+    }
+    expected_f_stride *= a.shape(i);
+  }
+  if (is_f_contig)
+  {
+    return xt::layout_type::column_major;
+  }
+
+  return xt::layout_type::any; // should never happen
+}
+
+} // namespace detail
+
+template <typename T> auto xt_adapt_ndarray(nb_array_type<T> arr)
+{
+  return xt::adapt_smart_ptr<xt::layout_type::dynamic>(
+      arr.data(), detail::shape_from_nb(arr),
+      std::make_unique<nb_array_type<T>>(arr), detail::layout_from_nb(arr));
+}
+
+// template <typename T>
+// using xt_ndarray =
+//   decltype(xt_adapt_ndarray(std::declval<nb_array_type<T>>()));
+
+template <typename T>
+using xt_ndarray =
+    xt::xarray_adaptor<xt::xbuffer_adaptor<T *, xt::smart_ownership,
+                                           std::unique_ptr<nb_array_type<T>>>,
+                       xt::layout_type::dynamic, std::vector<std::size_t>>;
+
 NAMESPACE_BEGIN(NB_NAMESPACE)
 NAMESPACE_BEGIN(detail)
 
@@ -17,6 +99,12 @@ template <typename Type, size_t Size>
 struct type_caster<xt::xtensor_fixed<Type, xt::xshape<Size>>>
     : array_caster<xt::xtensor_fixed<Type, xt::xshape<Size>>, Type, Size>
 {
+};
+
+template <typename T> struct type_caster<xt_ndarray<T>>
+{
+  NB_TYPE_CASTER(xt::xarray<T>,
+                 const_name("xt_ndarray<") + const_name<T>() + const_name(">"));
 };
 
 NAMESPACE_END(detail)
@@ -42,18 +130,7 @@ private:
 class test_xtadapt
 {
 public:
-  using nb_array_type = nb::ndarray<double, nb::any_contig>;
-  using xt_adapter_type =
-      decltype(xt::adapt_smart_ptr<xt::layout_type::dynamic>(
-          std::declval<double *>(), std::declval<std::vector<std::size_t>>(),
-          std::declval<std::unique_ptr<nb_array_type>>()));
-
-  test_xtadapt(nb_array_type a)
-      : a_xt_(xt::adapt_smart_ptr<xt::layout_type::dynamic>(
-            a.data(), shape_from_nb(a), std::make_unique<nb_array_type>(a),
-            layout_from_nb(a)))
-  {
-  }
+  test_xtadapt(nb_array_type<double> a) : a_xt_(xt_adapt_ndarray(a)) {}
 
   double operator()(std::size_t i) const { return a_xt_(i); }
   double operator()(std::size_t i, std::size_t j) const { return a_xt_(i, j); }
@@ -75,64 +152,7 @@ public:
   }
 
 private:
-  std::vector<std::size_t> shape_from_nb(const nb_array_type &a)
-  {
-    std::vector<std::size_t> shape(a.ndim());
-    for (std::size_t i = 0; i < a.ndim(); ++i)
-    {
-      shape[i] = a.shape(i);
-    }
-    return shape;
-  }
-
-  xt::layout_type layout_from_nb(const nb_array_type &a)
-  {
-    size_t ndim = a.ndim();
-
-    // 0D or 1D arrays are contiguous in both definitions
-    if (ndim <= 1)
-    {
-      return xt::layout_type::row_major; // F as well...
-    }
-
-    // Expected stride for the next dimension
-    std::size_t expected_c_stride = 1;
-    std::size_t expected_f_stride = 1;
-
-    // Check C-Contiguous (Row-Major): Strides increase from right to left
-    bool is_c_contig = true;
-    for (int i = (int)ndim - 1; i >= 0; --i)
-    {
-      if (a.stride(i) != expected_c_stride)
-      {
-        is_c_contig = false;
-      }
-      expected_c_stride *= a.shape(i);
-    }
-    if (is_c_contig)
-    {
-      return xt::layout_type::row_major;
-    }
-
-    // Check F-Contiguous (Column-Major): Strides increase from left to right
-    bool is_f_contig = true;
-    for (size_t i = 0; i < ndim; ++i)
-    {
-      if (a.stride(i) != expected_f_stride)
-      {
-        is_f_contig = false;
-      }
-      expected_f_stride *= a.shape(i);
-    }
-    if (is_f_contig)
-    {
-      return xt::layout_type::column_major;
-    }
-
-    return xt::layout_type::any; // should never happen
-  }
-
-  xt_adapter_type a_xt_;
+  xt_ndarray<double> a_xt_;
 };
 } // namespace test
 
@@ -141,12 +161,14 @@ NB_MODULE(_openggcm, m)
   m.def("xt_fixed_from_python",
         [](xt::xtensor_fixed<double, xt::xshape<3>> a) { return a; });
 
+  // m.def("xt_adaptor_type_from_python", [](xt_adaptor_type a) {});
+
   nb::class_<test::test_ndarray>(m, "test_ndarray")
       .def(nb::init<nb::ndarray<double, nb::ndim<1>>>())
       .def("__getitem__", &test::test_ndarray::operator[], "i"_a);
 
   nb::class_<test::test_xtadapt>(m, "test_xtadapt")
-      .def(nb::init<test::test_xtadapt::nb_array_type>(), nb::arg().noconvert())
+      .def(nb::init<nb_array_type<double>>(), nb::arg().noconvert())
       .def("__getitem__",
            [](test::test_xtadapt &self, std::size_t i) { return self(i); })
       .def("__getitem__",

--- a/tests/test_bind.py
+++ b/tests/test_bind.py
@@ -35,3 +35,23 @@ def test_test_xtadapt():
     assert b[1] == 5.0
     del b
     assert sys.getrefcount(a) == 2
+
+
+def test_test_xtadapt_2d():
+    a = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    b = _openggcm.test_xtadapt(a)
+    assert b[1, 2] == 6.0
+    a[1, 2] = 50.0
+    assert b[1, 2] == 50.0
+
+
+# def test_test_xtadapt_2d_fortran():
+#     a = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], order='F')
+#     b = _openggcm.test_xtadapt(a)
+#     print("b[1,2] = ", b[1, 2])
+#     assert b[1, 2] == 6.0
+#     assert b[1, 1] == 5.0
+#     a[1, 2] = 60.0
+#     a[1, 1] = 50.0
+#     assert b[1, 2] == 60.0
+#     assert b[1, 1] == 50.0

--- a/tests/test_bind.py
+++ b/tests/test_bind.py
@@ -11,6 +11,24 @@ def test_xt_fixed_from_python():
     assert np.array_equal(b, a)
 
 
+def test_xt_array_from_python():
+    a = np.array([1.0, 2.0, 3.0])
+    _openggcm.xt_array_from_python(a)
+    assert np.allclose(a, [1.0, 2.0, 3.0])
+
+
+def test_xt_ndarray_from_python_manual():
+    a = np.array([1.0, 2.0, 3.0])
+    _openggcm.xt_ndarray_from_python_manual(a)
+    assert np.allclose(a, [1.0, 99.0, 3.0])
+
+
+# def test_xt_ndarray_from_python():
+#     a = np.array([1.0, 2.0, 3.0])
+#     _openggcm.xt_ndarray_from_python(a)
+#     assert np.allclose(a, [1.0, 99.0, 3.0])
+
+
 def test_test_ndarray():
     import sys
 

--- a/tests/test_bind.py
+++ b/tests/test_bind.py
@@ -33,26 +33,30 @@ def test_test_ndarray():
     import sys
 
     a = np.array([1.0, 2.0, 3.0])
-    assert sys.getrefcount(a) == 2
+    refcount = sys.getrefcount(a)
+    assert refcount >= 1
     b = _openggcm.test_ndarray(a)
-    assert sys.getrefcount(a) == 4
+    assert sys.getrefcount(a) > refcount
     assert b[1] == 2.0
     a[1] = 5.0
     assert b[1] == 5.0
     del b
-    assert sys.getrefcount(a) == 2
+    assert sys.getrefcount(a) == refcount
 
 
 def test_test_xtadapt():
     import sys
 
     a = np.array([1.0, 2.0, 3.0])
+    refcount = sys.getrefcount(a)
+    assert refcount >= 1
     b = _openggcm.test_xtadapt(a)
+    assert sys.getrefcount(a) > refcount
     assert b[1] == 2.0
     a[1] = 5.0
     assert b[1] == 5.0
     del b
-    assert sys.getrefcount(a) == 2
+    assert sys.getrefcount(a) == refcount
 
 
 def test_test_xtadapt_2d():

--- a/tests/test_bind.py
+++ b/tests/test_bind.py
@@ -9,3 +9,17 @@ def test_xt_fixed_from_python():
     a = [1.0, 2.0, 3.0]
     b = _openggcm.xt_fixed_from_python(a)
     assert np.array_equal(b, a)
+
+
+def test_test_ndarray():
+    import sys
+
+    a = np.array([1.0, 2.0, 3.0])
+    assert sys.getrefcount(a) == 2
+    b = _openggcm.test_ndarray(a)
+    assert sys.getrefcount(a) == 4
+    assert b[1] == 2.0
+    a[1] = 5.0
+    assert b[1] == 5.0
+    del b
+    assert sys.getrefcount(a) == 2

--- a/tests/test_bind.py
+++ b/tests/test_bind.py
@@ -45,13 +45,12 @@ def test_test_xtadapt_2d():
     assert b[1, 2] == 50.0
 
 
-# def test_test_xtadapt_2d_fortran():
-#     a = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], order='F')
-#     b = _openggcm.test_xtadapt(a)
-#     print("b[1,2] = ", b[1, 2])
-#     assert b[1, 2] == 6.0
-#     assert b[1, 1] == 5.0
-#     a[1, 2] = 60.0
-#     a[1, 1] = 50.0
-#     assert b[1, 2] == 60.0
-#     assert b[1, 1] == 50.0
+def test_test_xtadapt_2d_fortran():
+    a = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], order="F")
+    b = _openggcm.test_xtadapt(a)
+    assert b[1, 2] == 6.0
+    assert b[1, 1] == 5.0
+    a[1, 2] = 60.0
+    a[1, 1] = 50.0
+    assert b[1, 2] == 60.0
+    assert b[1, 1] == 50.0

--- a/tests/test_bind.py
+++ b/tests/test_bind.py
@@ -23,3 +23,15 @@ def test_test_ndarray():
     assert b[1] == 5.0
     del b
     assert sys.getrefcount(a) == 2
+
+
+def test_test_xtadapt():
+    import sys
+
+    a = np.array([1.0, 2.0, 3.0])
+    b = _openggcm.test_xtadapt(a)
+    assert b[1] == 2.0
+    a[1] = 5.0
+    assert b[1] == 5.0
+    del b
+    assert sys.getrefcount(a) == 2


### PR DESCRIPTION
This actually could needs some more work, as the conversion to an xtensor adapted view works, but not the automatically via casting...

This pull request adds support for converting Python `numpy` arrays to C++ `xtensor` types in the nanobind-based bindings, as well as comprehensive tests for these conversions. The main changes include implementing type casters for `xt::xarray`, utilities for adapting nanobind ndarrays to xtensor, and new test cases to verify correct data sharing and memory management.

### Python-to-C++ array conversion and adaptation

* Added a type caster for `xt::xarray<T>` to enable automatic conversion from Python `numpy` arrays to C++ `xtensor` arrays in nanobind bindings.
* Implemented the `xt_adapt_ndarray` utility and supporting functions to adapt nanobind ndarrays to `xtensor` views, preserving shape, strides, and layout (row-major/column-major).

### Test coverage for conversions and memory management

* Added several tests in `test_bind.py` to verify conversions, data sharing, and correct reference counting between Python and C++ for `xtensor` and nanobind ndarray types.
* Introduced test classes and binding functions in C++ to expose and exercise the new conversion logic, including multi-dimensional and Fortran-ordered arrays.

These changes significantly improve the interoperability between Python and C++ for numerical data in this codebase.