### PR TITLE
Implement cic_weights() and improve TSC interpolation in tracing/ip

### DIFF
--- a/src/ggcmpy/libopenggcm/include/openggcm/emfields.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/emfields.hxx
@@ -71,10 +71,10 @@ namespace interpolate
 
 constexpr double NaN = std::numeric_limits<double>::quiet_NaN();
 
-class cic_weights
+template <typename Container> class cic_weights
 {
 public:
-  cic_weights(const xt::xtensor<double, 1> &crd) : crd_(crd) {}
+  cic_weights(const Container &crd) : crd_(crd) {}
 
   std::pair<std::size_t, double2> operator()(double x) const
   {
@@ -90,7 +90,7 @@ public:
   }
 
 private:
-  xt::xtensor<double, 1> crd_;
+  const Container &crd_;
 };
 
 } // namespace interpolate

--- a/src/ggcmpy/libopenggcm/include/openggcm/emfields.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/emfields.hxx
@@ -96,6 +96,45 @@ private:
 template <typename Container>
 cic_weights(Container &&crd) -> cic_weights<Container>;
 
+template <typename Container> class tsc_weights
+{
+public:
+  tsc_weights(Container &&crd) : crd_(std::forward<Container>(crd)) {}
+
+  std::pair<std::size_t, double3> operator()(double x) const
+  {
+    auto it = std::lower_bound(crd_.data(), crd_.data() + crd_.size(), x);
+    auto i = std::distance(crd_.data(), it) - 1;
+    if (i < 0 || i >= crd_.size() - 1)
+    {
+      return {std::size_t(-1), {NaN, NaN, NaN}};
+    }
+    assert(crd_(i) < x && x <= crd_(i + 1));
+    double h = (x - crd_(i)) / (crd_(i + 1) - crd_(i));
+    if (h >= 0.5)
+    {
+      i++;
+      h -= 1.0;
+    }
+
+    if (i < 1 || i >= crd_.size() - 1)
+    {
+      return {std::size_t(-1), {NaN, NaN, NaN}};
+    }
+
+    double wm = 0.5 * sqr(0.5 - h);
+    double wp = 0.5 * sqr(0.5 + h);
+    double w0 = 1.0 - wm - wp;
+    return {i - 1, {wm, w0, wp}};
+  }
+
+private:
+  Container crd_;
+};
+
+template <typename Container>
+tsc_weights(Container &&crd) -> tsc_weights<Container>;
+
 } // namespace interpolate
 
 template <typename Container1d, typename Container3d>
@@ -163,6 +202,71 @@ private:
             f(ix + 1, iy + 0, iz + 1) * wx[1] * wy[0] * wz[1] +
             f(ix + 0, iy + 1, iz + 1) * wx[0] * wy[1] * wz[1] +
             f(ix + 1, iy + 1, iz + 1) * wx[1] * wy[1] * wz[1]);
+  }
+};
+
+template <typename Container1d, typename Container3d>
+class emfields_yee_tsc : public emfields_yee<Container1d, Container3d>
+{
+public:
+  using base_type = emfields_yee<Container1d, Container3d>;
+  using typename base_type::array1d;
+  using typename base_type::array3d;
+
+  using base_type::base_type;
+
+  double3 E(double3 r) const override
+  {
+    return {interpolate(r, this->e1x_, this->x_, this->y_nc_, this->z_nc_),
+            interpolate(r, this->e1y_, this->x_nc_, this->y_, this->z_nc_),
+            interpolate(r, this->e1z_, this->x_nc_, this->y_nc_, this->z_)};
+  }
+
+  double3 B(double3 r) const override
+  {
+    return {interpolate(r, this->b1x_, this->x_nc_, this->y_, this->z_),
+            interpolate(r, this->b1y_, this->x_, this->y_nc_, this->z_),
+            interpolate(r, this->b1z_, this->x_, this->y_, this->z_nc_)};
+  }
+
+  std::string repr() const override { return "emfields_yee_cic()"; }
+
+private:
+  static double interpolate(const double3 &r, const array3d &f,
+                            const array1d &x, const array1d &y,
+                            const array1d &z)
+  {
+    auto [ix, wx] = interpolate::tsc_weights(x)(r(0));
+    auto [iy, wy] = interpolate::tsc_weights(y)(r(1));
+    auto [iz, wz] = interpolate::tsc_weights(z)(r(2));
+
+    return (f(ix + 0, iy + 0, iz + 0) * wx[0] * wy[0] * wz[0] +
+            f(ix + 1, iy + 0, iz + 0) * wx[1] * wy[0] * wz[0] +
+            f(ix + 2, iy + 0, iz + 0) * wx[2] * wy[0] * wz[0] +
+            f(ix + 0, iy + 1, iz + 0) * wx[0] * wy[1] * wz[0] +
+            f(ix + 1, iy + 1, iz + 0) * wx[1] * wy[1] * wz[0] +
+            f(ix + 2, iy + 1, iz + 0) * wx[2] * wy[1] * wz[0] +
+            f(ix + 0, iy + 2, iz + 0) * wx[0] * wy[2] * wz[0] +
+            f(ix + 1, iy + 2, iz + 0) * wx[1] * wy[2] * wz[0] +
+            f(ix + 2, iy + 2, iz + 0) * wx[2] * wy[2] * wz[0] +
+            f(ix + 0, iy + 0, iz + 1) * wx[0] * wy[0] * wz[1] +
+            f(ix + 1, iy + 0, iz + 1) * wx[1] * wy[0] * wz[1] +
+            f(ix + 2, iy + 0, iz + 1) * wx[2] * wy[0] * wz[1] +
+            f(ix + 0, iy + 1, iz + 1) * wx[0] * wy[1] * wz[1] +
+            f(ix + 1, iy + 1, iz + 1) * wx[1] * wy[1] * wz[1] +
+            f(ix + 2, iy + 1, iz + 1) * wx[2] * wy[1] * wz[1] +
+            f(ix + 0, iy + 2, iz + 1) * wx[0] * wy[2] * wz[1] +
+            f(ix + 1, iy + 2, iz + 1) * wx[1] * wy[2] * wz[1] +
+            f(ix + 2, iy + 2, iz + 1) * wx[2] * wy[2] * wz[1] +
+            f(ix + 0, iy + 0, iz + 2) * wx[0] * wy[0] * wz[2] +
+            f(ix + 1, iy + 0, iz + 2) * wx[1] * wy[0] * wz[2] +
+            f(ix + 2, iy + 0, iz + 2) * wx[2] * wy[0] * wz[2] +
+            f(ix + 0, iy + 1, iz + 2) * wx[0] * wy[1] * wz[2] +
+            f(ix + 1, iy + 1, iz + 2) * wx[1] * wy[1] * wz[2] +
+            f(ix + 2, iy + 1, iz + 2) * wx[2] * wy[1] * wz[2] +
+            f(ix + 0, iy + 2, iz + 2) * wx[0] * wy[2] * wz[2] +
+            f(ix + 1, iy + 2, iz + 2) * wx[1] * wy[2] * wz[2] +
+            f(ix + 2, iy + 2, iz + 2) * wx[2] * wy[2] * wz[2]);
   }
 };
 

--- a/src/ggcmpy/libopenggcm/include/openggcm/emfields.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/emfields.hxx
@@ -4,6 +4,8 @@
 #include <openggcm/constants.hxx>
 #include <openggcm/util.hxx>
 
+#include <xtensor/containers/xtensor.hpp>
+
 #include <string>
 
 namespace openggcm
@@ -63,5 +65,34 @@ public:
 private:
   double3 m_; // magnetic moment
 };
+
+namespace interpolate
+{
+
+constexpr double NaN = std::numeric_limits<double>::quiet_NaN();
+
+class cic_weights
+{
+public:
+  cic_weights(const xt::xtensor<double, 1> &crd) : crd_(crd) {}
+
+  std::pair<std::size_t, double2> operator()(double x) const
+  {
+    auto it = std::upper_bound(crd_.cbegin(), crd_.cend(), x);
+    std::size_t i = std::distance(crd_.cbegin(), it) - 1;
+    if (i >= crd_.size() - 1)
+    {
+      return {std::size_t(-1), {NaN, NaN}};
+    }
+    double w1 = (x - crd_(i)) / (crd_(i + 1) - crd_(i));
+    double w0 = 1.0 - w1;
+    return {i, {w0, w1}};
+  }
+
+private:
+  xt::xtensor<double, 1> crd_;
+};
+
+} // namespace interpolate
 
 } // namespace openggcm

--- a/src/ggcmpy/libopenggcm/include/openggcm/emfields.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/emfields.hxx
@@ -95,4 +95,72 @@ private:
 
 } // namespace interpolate
 
+template <typename Container1d, typename Container3d>
+class emfields_yee : public emfields
+{
+public:
+  using array1d = Container1d;
+  using array3d = Container3d;
+
+  emfields_yee(array3d e1x, array3d e1y, array3d e1z, array3d b1x, array3d b1y,
+               array3d b1z, array1d x, array1d y, array1d z, array1d x_nc,
+               array1d y_nc, array1d z_nc)
+      : e1x_(e1x), e1y_(e1y), e1z_(e1z), b1x_(b1x), b1y_(b1y), b1z_(b1z), x_(x),
+        y_(y), z_(z), x_nc_(x_nc), y_nc_(y_nc), z_nc_(z_nc)
+  {
+  }
+
+protected:
+  array3d e1x_, e1y_, e1z_;
+  array3d b1x_, b1y_, b1z_;
+  array1d x_, y_, z_;
+  array1d x_nc_, y_nc_, z_nc_;
+};
+
+template <typename Container1d, typename Container3d>
+class emfields_yee_cic : public emfields_yee<Container1d, Container3d>
+{
+public:
+  using base_type = emfields_yee<Container1d, Container3d>;
+  using typename base_type::array1d;
+  using typename base_type::array3d;
+
+  using base_type::base_type;
+
+  double3 E(double3 r) const override
+  {
+    return {interpolate(r, this->e1x_, this->x_, this->y_nc_, this->z_nc_),
+            interpolate(r, this->e1y_, this->x_nc_, this->y_, this->z_nc_),
+            interpolate(r, this->e1z_, this->x_nc_, this->y_nc_, this->z_)};
+  }
+
+  double3 B(double3 r) const override
+  {
+    return {interpolate(r, this->b1x_, this->x_nc_, this->y_, this->z_),
+            interpolate(r, this->b1y_, this->x_, this->y_nc_, this->z_),
+            interpolate(r, this->b1z_, this->x_, this->y_, this->z_nc_)};
+  }
+
+  std::string repr() const override { return "emfields_yee_cic()"; }
+
+private:
+  static double interpolate(const double3 &r, const array3d &f,
+                            const array1d &x, const array1d &y,
+                            const array1d &z)
+  {
+    auto [ix, wx] = interpolate::cic_weights(x)(r(0));
+    auto [iy, wy] = interpolate::cic_weights(y)(r(1));
+    auto [iz, wz] = interpolate::cic_weights(z)(r(2));
+
+    return (f(ix + 0, iy + 0, iz + 0) * wx[0] * wy[0] * wz[0] +
+            f(ix + 1, iy + 0, iz + 0) * wx[1] * wy[0] * wz[0] +
+            f(ix + 0, iy + 1, iz + 0) * wx[0] * wy[1] * wz[0] +
+            f(ix + 1, iy + 1, iz + 0) * wx[1] * wy[1] * wz[0] +
+            f(ix + 0, iy + 0, iz + 1) * wx[0] * wy[0] * wz[1] +
+            f(ix + 1, iy + 0, iz + 1) * wx[1] * wy[0] * wz[1] +
+            f(ix + 0, iy + 1, iz + 1) * wx[0] * wy[1] * wz[1] +
+            f(ix + 1, iy + 1, iz + 1) * wx[1] * wy[1] * wz[1]);
+  }
+};
+
 } // namespace openggcm

--- a/src/ggcmpy/libopenggcm/include/openggcm/emfields.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/emfields.hxx
@@ -74,7 +74,7 @@ constexpr double NaN = std::numeric_limits<double>::quiet_NaN();
 template <typename Container> class cic_weights
 {
 public:
-  cic_weights(const Container &crd) : crd_(crd) {}
+  cic_weights(Container &&crd) : crd_(std::forward<Container>(crd)) {}
 
   std::pair<std::size_t, double2> operator()(double x) const
   {
@@ -90,8 +90,11 @@ public:
   }
 
 private:
-  const Container &crd_;
+  Container crd_;
 };
+
+template <typename Container>
+cic_weights(Container &&crd) -> cic_weights<Container>;
 
 } // namespace interpolate
 

--- a/src/ggcmpy/libopenggcm/include/openggcm/emfields.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/emfields.hxx
@@ -125,7 +125,7 @@ public:
     double wm = 0.5 * sqr(0.5 - h);
     double wp = 0.5 * sqr(0.5 + h);
     double w0 = 1.0 - wm - wp;
-    return {i - 1, {wm, w0, wp}};
+    return {std::size_t(i - 1), {wm, w0, wp}};
   }
 
 private:

--- a/src/ggcmpy/libopenggcm/include/openggcm/emfields.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/emfields.hxx
@@ -78,8 +78,8 @@ public:
 
   std::pair<std::size_t, double2> operator()(double x) const
   {
-    auto it = std::upper_bound(crd_.cbegin(), crd_.cend(), x);
-    std::size_t i = std::distance(crd_.cbegin(), it) - 1;
+    auto it = std::upper_bound(crd_.data(), crd_.data() + crd_.size(), x);
+    std::size_t i = std::distance(crd_.data(), it) - 1;
     if (i >= crd_.size() - 1)
     {
       return {std::size_t(-1), {NaN, NaN}};

--- a/src/ggcmpy/libopenggcm/include/openggcm/util.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/util.hxx
@@ -6,6 +6,7 @@
 namespace openggcm
 {
 
+using double2 = xt::xtensor_fixed<double, xt::xshape<2>>;
 using double3 = xt::xtensor_fixed<double, xt::xshape<3>>;
 
 inline double sqr(double x) { return x * x; }

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -250,4 +250,11 @@ NB_MODULE(_openggcm, m)
                     array1d, array1d, array1d, array1d, array1d, array1d>(),
            "e1x"_a, "e1y"_a, "e1z"_a, "b1x"_a, "b1y"_a, "b1z"_a, "x"_a, "y"_a,
            "z"_a, "x_nc"_a, "y_nc"_a, "z_nc"_a);
+
+  nb::class_<emfields_yee_tsc<array1d, array3d>,
+             emfields_yee<array1d, array3d>>(m, "emfields_yee_tsc")
+      .def(nb::init<array3d, array3d, array3d, array3d, array3d, array3d,
+                    array1d, array1d, array1d, array1d, array1d, array1d>(),
+           "e1x"_a, "e1y"_a, "e1z"_a, "b1x"_a, "b1y"_a, "b1z"_a, "x"_a, "y"_a,
+           "z"_a, "x_nc"_a, "y_nc"_a, "z_nc"_a);
 }

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -238,4 +238,16 @@ NB_MODULE(_openggcm, m)
 
   nb::class_<emfields_dipole, emfields>(m, "emfields_dipole")
       .def(nb::init<double3>(), "m"_a);
+
+  using array1d = nb::ndarray<const double, nb::ndim<1>, nb::any_contig>;
+  using array3d = nb::ndarray<const double, nb::ndim<3>, nb::any_contig>;
+
+  nb::class_<emfields_yee<array1d, array3d>, emfields>(m, "emfields_yee");
+
+  nb::class_<emfields_yee_cic<array1d, array3d>,
+             emfields_yee<array1d, array3d>>(m, "emfields_yee_cic")
+      .def(nb::init<array3d, array3d, array3d, array3d, array3d, array3d,
+                    array1d, array1d, array1d, array1d, array1d, array1d>(),
+           "e1x"_a, "e1y"_a, "e1z"_a, "b1x"_a, "b1y"_a, "b1z"_a, "x"_a, "y"_a,
+           "z"_a, "x_nc"_a, "y_nc"_a, "z_nc"_a);
 }

--- a/src/ggcmpy/libopenggcm/tests/test_emfields.cxx
+++ b/src/ggcmpy/libopenggcm/tests/test_emfields.cxx
@@ -14,3 +14,30 @@ TEST(EmfieldsTest, ConstantFields)
   EXPECT_EQ(fields.E({0.0, 0.0, 0.0}), E_0);
   EXPECT_EQ(fields.B({0.0, 0.0, 0.0}), B_0);
 }
+
+TEST(interpolate, cic_weights)
+{
+  xt::xtensor<double, 1> crd = {1.0, 2.0, 4.0};
+  interpolate::cic_weights weights(crd);
+
+  {
+    auto [i, w] = weights(2.5);
+    EXPECT_EQ(i, 1);
+    EXPECT_NEAR(w[0], 0.75, 1e-10);
+    EXPECT_NEAR(w[1], 0.25, 1e-10);
+  }
+
+  {
+    auto [i, w] = weights(.5);
+    EXPECT_EQ(i, std::size_t(-1));
+    EXPECT_TRUE(std::isnan(w[0]));
+    EXPECT_TRUE(std::isnan(w[1]));
+  }
+
+  {
+    auto [i, w] = weights(4.5);
+    EXPECT_EQ(i, std::size_t(-1));
+    EXPECT_TRUE(std::isnan(w[0]));
+    EXPECT_TRUE(std::isnan(w[1]));
+  }
+}

--- a/src/ggcmpy/libopenggcm/tests/test_emfields.cxx
+++ b/src/ggcmpy/libopenggcm/tests/test_emfields.cxx
@@ -41,3 +41,41 @@ TEST(interpolate, cic_weights)
     EXPECT_TRUE(std::isnan(w[1]));
   }
 }
+
+TEST(interpolate, tsc_weights)
+{
+  xt::xtensor<double, 1> crd = {1.0, 2.0, 3.0};
+  interpolate::tsc_weights weights(crd);
+
+  {
+    auto [i, w] = weights(2.0);
+    EXPECT_EQ(i, 0);
+    EXPECT_NEAR(w[0], 0.125, 1e-10);
+    EXPECT_NEAR(w[1], 0.75, 1e-10);
+    EXPECT_NEAR(w[2], 0.125, 1e-10);
+  }
+
+  {
+    auto [i, w] = weights(1.5);
+    EXPECT_EQ(i, 0);
+    EXPECT_NEAR(w[0], 0.5, 1e-10);
+    EXPECT_NEAR(w[1], 0.5, 1e-10);
+    EXPECT_NEAR(w[2], 0.0, 1e-10);
+  }
+
+  {
+    auto [i, w] = weights(1.2);
+    EXPECT_EQ(i, std::size_t(-1));
+    EXPECT_TRUE(std::isnan(w[0]));
+    EXPECT_TRUE(std::isnan(w[1]));
+    EXPECT_TRUE(std::isnan(w[2]));
+  }
+
+  {
+    auto [i, w] = weights(2.8);
+    EXPECT_EQ(i, std::size_t(-1));
+    EXPECT_TRUE(std::isnan(w[0]));
+    EXPECT_TRUE(std::isnan(w[1]));
+    EXPECT_TRUE(std::isnan(w[2]));
+  }
+}

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -147,12 +147,10 @@ class BorisIntegrator_python:
     def __init__(self, ds, q=constants.e, m=constants.m_e) -> None:
         self.q = q
         self.m = m
-        self._interpolator: (
-            emfields.interpolator_python | emfields.interpolator_yee_python
-        )
+        self._interpolator: emfields.interpolator_python | emfields.yee_cic_python
         if isinstance(ds, xr.Dataset):
             if {"bx1", "by1", "bz1", "eflx", "efly", "eflz"} <= ds.data_vars.keys():
-                self._interpolator = emfields.interpolator_yee_python(ds)
+                self._interpolator = emfields.yee_cic_python(ds)
             else:
                 self._interpolator = emfields.interpolator_python(ds)
         else:

--- a/src/ggcmpy/tracing/emfields.py
+++ b/src/ggcmpy/tracing/emfields.py
@@ -122,13 +122,13 @@ class yee_cic_python:
         return float(val)
 
 
-class yee_cic_cxx:
+class yee_cic_cxx(_openggcm.emfields_yee_cic):  # type: ignore[misc]
     """
     A class representing a Yee grid interpolator assuming CIC (Cloud in Cell) using C++.
     """
 
     def __init__(self, ds: xr.Dataset) -> None:
-        self._ip = _openggcm.emfields_yee_cic(
+        super().__init__(
             ds["eflx"].to_numpy(),
             ds["efly"].to_numpy(),
             ds["eflz"].to_numpy(),
@@ -143,11 +143,27 @@ class yee_cic_cxx:
             ds["z_nc"].to_numpy(),
         )
 
-    def B(self, point: np.ndarray) -> np.ndarray:
-        return self._ip.B(point)  # type: ignore[no-any-return]
 
-    def E(self, point: np.ndarray) -> np.ndarray:
-        return self._ip.E(point)  # type: ignore[no-any-return]
+class yee_tsc_cxx(_openggcm.emfields_yee_tsc):  # type: ignore[misc]
+    """
+    A class representing a Yee grid interpolator assuming TSC (Triangular Shaped Cloud) using C++.
+    """
+
+    def __init__(self, ds: xr.Dataset) -> None:
+        super().__init__(
+            ds["eflx"].to_numpy(),
+            ds["efly"].to_numpy(),
+            ds["eflz"].to_numpy(),
+            ds["bx1"].to_numpy(),
+            ds["by1"].to_numpy(),
+            ds["bz1"].to_numpy(),
+            ds["x"].to_numpy(),
+            ds["y"].to_numpy(),
+            ds["z"].to_numpy(),
+            ds["x_nc"].to_numpy(),
+            ds["y_nc"].to_numpy(),
+            ds["z_nc"].to_numpy(),
+        )
 
 
 # Default implementations

--- a/src/ggcmpy/tracing/emfields.py
+++ b/src/ggcmpy/tracing/emfields.py
@@ -122,6 +122,34 @@ class interpolator_yee_python:
         return float(val)
 
 
+class yee_cic_cxx:
+    """
+    A class representing a Yee grid interpolator assuming CIC (Cloud in Cell) using C++.
+    """
+
+    def __init__(self, ds: xr.Dataset) -> None:
+        self._ip = _openggcm.emfields_yee_cic(
+            ds["eflx"].to_numpy(),
+            ds["efly"].to_numpy(),
+            ds["eflz"].to_numpy(),
+            ds["bx1"].to_numpy(),
+            ds["by1"].to_numpy(),
+            ds["bz1"].to_numpy(),
+            ds["x"].to_numpy(),
+            ds["y"].to_numpy(),
+            ds["z"].to_numpy(),
+            ds["x_nc"].to_numpy(),
+            ds["y_nc"].to_numpy(),
+            ds["z_nc"].to_numpy(),
+        )
+
+    def B(self, point: np.ndarray) -> np.ndarray:
+        return self._ip.B(point)  # type: ignore[no-any-return]
+
+    def E(self, point: np.ndarray) -> np.ndarray:
+        return self._ip.E(point)  # type: ignore[no-any-return]
+
+
 # Default implementations
 
 uniform = uniform_python

--- a/src/ggcmpy/tracing/emfields.py
+++ b/src/ggcmpy/tracing/emfields.py
@@ -95,7 +95,7 @@ class interpolator_python:
         return float(val)
 
 
-class interpolator_yee_python:
+class yee_cic_python:
     """
     A class for interpolating electromagnetic field components from a xarray.Dataset on a Yee grid.
     """

--- a/tests/test_emfields.py
+++ b/tests/test_emfields.py
@@ -29,10 +29,10 @@ e1_grid = [
 
 
 def make_coords() -> dict[str, np.ndarray]:
-    coords = {fld: np.linspace(-1.0, 1.0, 10) for fld in ["x", "y", "z"]}
+    coords = {f"{dir}_nc": np.linspace(-1.0, 1.0, 11) for dir in ["x", "y", "z"]}
     coords |= {
-        crd + "_nc": 0.5 * (coords[crd][:-1] + coords[crd][1:])
-        for crd in ["x", "y", "z"]
+        dir: 0.5 * (coords[f"{dir}_nc"][:-1] + coords[f"{dir}_nc"][1:])
+        for dir in ["x", "y", "z"]
     }
     return coords
 

--- a/tests/test_emfields.py
+++ b/tests/test_emfields.py
@@ -121,7 +121,7 @@ def test_emfields_interpolator(interpolator):
 @pytest.mark.parametrize(
     "interpolator",
     [
-        ggcmpy.tracing.emfields.interpolator_yee_python,
+        ggcmpy.tracing.emfields.yee_cic_python,
         ggcmpy.tracing.FieldInterpolatorYee_f2py,
         ggcmpy.tracing.emfields.yee_cic_cxx,
     ],

--- a/tests/test_emfields.py
+++ b/tests/test_emfields.py
@@ -101,7 +101,7 @@ def test_emfields_dipole(emfields_dipole):
         ggcmpy.tracing.FieldInterpolator_f2py,
     ],
 )
-def test_efields_interpolator(interpolator):
+def test_emfields_interpolator(interpolator):
     emfields = emfields_test()
 
     coords = make_coords()
@@ -123,9 +123,10 @@ def test_efields_interpolator(interpolator):
     [
         ggcmpy.tracing.emfields.interpolator_yee_python,
         ggcmpy.tracing.FieldInterpolatorYee_f2py,
+        ggcmpy.tracing.emfields.yee_cic_cxx,
     ],
 )
-def test_FieldInterpolatorYee(interpolator):
+def test_emfields_yee(interpolator):
     emfields = emfields_test()
 
     coords = make_coords()
@@ -138,5 +139,5 @@ def test_FieldInterpolatorYee(interpolator):
     emfields_ip = interpolator(emfields_yee)
     point = np.array([0.1, 0.25, 0.3])
     # since the original field is linear, the interpolation should be exact
-    assert np.allclose(emfields_ip.B(point), emfields.B(point))
-    assert np.allclose(emfields_ip.E(point), emfields.E(point))
+    assert np.allclose(emfields_ip.B(point), emfields.B(point), atol=1e-7)
+    assert np.allclose(emfields_ip.E(point), emfields.E(point), atol=1e-7)

--- a/tests/test_emfields.py
+++ b/tests/test_emfields.py
@@ -124,6 +124,7 @@ def test_emfields_interpolator(interpolator):
         ggcmpy.tracing.emfields.yee_cic_python,
         ggcmpy.tracing.FieldInterpolatorYee_f2py,
         ggcmpy.tracing.emfields.yee_cic_cxx,
+        ggcmpy.tracing.emfields.yee_tsc_cxx,  # since the original field is linear, TSC interpolation should still be exact
     ],
 )
 def test_emfields_yee(interpolator):


### PR DESCRIPTION
This pull request introduces new C++ implementations for electromagnetic field interpolation on Yee grids using both CIC (Cloud-In-Cell) and TSC (Triangular Shaped Cloud) schemes, exposes them to Python, and updates the Python and test code to use and validate these new interpolators. The changes improve both the flexibility and accuracy of field interpolation in the codebase.

**Key changes:**

### C++ Core Interpolation and Interface

* Added C++ implementations for `cic_weights` and `tsc_weights` interpolation schemes, and new classes `emfields_yee`, `emfields_yee_cic`, and `emfields_yee_tsc` for Yee grid field interpolation, with detailed logic for each method.
* Exposed the new C++ classes to Python via nanobind, enabling their use in Python code.

### Python Interface and Usage

* Added Python wrapper classes `yee_cic_cxx` and `yee_tsc_cxx` for the new C++ interpolators, and updated the default Python interpolator class for Yee grids to `yee_cic_python` for clarity. [[1]](diffhunk://#diff-04298adb77ac6413c9c95289f4168137c67b81aeae08c9bda304e162fcbd3513L98-R98) [[2]](diffhunk://#diff-04298adb77ac6413c9c95289f4168137c67b81aeae08c9bda304e162fcbd3513R125-R168)
* Updated the `BorisIntegrator_python` class to use the new `yee_cic_python` interpolator by default.

### Testing and Validation

* Added comprehensive C++ unit tests for the new `cic_weights` and `tsc_weights` interpolation logic, including edge case handling.
* Updated and expanded Python tests to cover both the new Python and C++ interpolators, including TSC, and ensured that coordinate generation and test tolerances are appropriate for the new implementations. [[1]](diffhunk://#diff-5c07dfa6cb64d2066c4c8962169d93d36ae9516deccdc707571f790ac5194bf5L32-R35) [[2]](diffhunk://#diff-5c07dfa6cb64d2066c4c8962169d93d36ae9516deccdc707571f790ac5194bf5L104-R104) [[3]](diffhunk://#diff-5c07dfa6cb64d2066c4c8962169d93d36ae9516deccdc707571f790ac5194bf5L124-R130) [[4]](diffhunk://#diff-5c07dfa6cb64d2066c4c8962169d93d36ae9516deccdc707571f790ac5194bf5L141-R144)

### Type and Utility Updates

* Added a new type alias `double2` for 2-element tensors to support the new interpolation schemes.

These changes collectively provide a more robust and extensible framework for electromagnetic field interpolation in both C++ and Python, improving performance and test coverage.