### PR TITLE
Minor fixes and add another Boris test

### DIFF
--- a/docs/tracing/openggcm.ipynb
+++ b/docs/tracing/openggcm.ipynb
@@ -71,9 +71,9 @@
     "ds[\"bx1\"] = ((\"x_nc\", \"y\", \"z\"), 1e-9 * ds.bx1.values[:-1, :, :])\n",
     "ds[\"by1\"] = ((\"x\", \"y_nc\", \"z\"), 1e-9 * ds.by1.values[:, :-1, :])\n",
     "ds[\"bz1\"] = ((\"x\", \"y\", \"z_nc\"), 1e-9 * ds.bz1.values[:, :, :-1])\n",
-    "ds[\"ex1\"] = ((\"x\", \"y_nc\", \"z_nc\"), 0 * ds.eflx.values[:, :-1, :-1])\n",
-    "ds[\"ey1\"] = ((\"x_nc\", \"y\", \"z_nc\"), 0 * ds.efly.values[:-1, :, :-1])\n",
-    "ds[\"ez1\"] = ((\"x_nc\", \"y_nc\", \"z\"), 0 * ds.eflz.values[:-1, :-1, :])\n",
+    "ds[\"eflx\"] = ((\"x\", \"y_nc\", \"z_nc\"), 0 * ds.eflx.values[:, :-1, :-1])\n",
+    "ds[\"efly\"] = ((\"x_nc\", \"y\", \"z_nc\"), 0 * ds.efly.values[:-1, :, :-1])\n",
+    "ds[\"eflz\"] = ((\"x_nc\", \"y_nc\", \"z\"), 0 * ds.eflz.values[:-1, :-1, :])\n",
     "ds"
    ]
   },
@@ -240,7 +240,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv-mac",
+   "display_name": ".venv-mac (3.12.12.final.0)",
    "language": "python",
    "name": "python3"
   },

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -177,14 +177,16 @@ class BorisIntegrator_python:
     def __init__(self, ds, q=constants.e, m=constants.m_e) -> None:
         self.q = q
         self.m = m
-        self._interpolator: emfields.interpolator_python | emfields.yee_cic_python
+        self._interpolator: (
+            emfields.uniform | emfields.interpolator_python | emfields.yee_cic_python
+        )
         if isinstance(ds, xr.Dataset):
             if {"bx1", "by1", "bz1", "eflx", "efly", "eflz"} <= ds.data_vars.keys():
                 self._interpolator = emfields.yee_cic_python(ds)
             else:
                 self._interpolator = emfields.interpolator_python(ds)
         else:
-            self._interpolator = ds  # assume it's already an interpolator
+            self._interpolator = ds  # assume it's already an emfields
 
     def integrate(self, x0, v0, t_max, dt_max=1.0, gyro_max=0.1) -> pd.DataFrame:
         t = 0.0

--- a/tests/test_particle_tracing.py
+++ b/tests/test_particle_tracing.py
@@ -59,6 +59,35 @@ def test_interpolate():
     )
 
 
+def test_BorisIntegrator_uniform():
+    """particle gyrating in a uniform magnetic field"""
+    q = constants.e  # [C]
+    m = constants.m_e  # [kg]
+    B_0 = 1e-8  # [T]
+    gamma = 1e-6 * np.sqrt(2.0)
+    emfields = ggcmpy.tracing.emfields.uniform(B_0=np.array([0.0, 0.0, B_0]))
+    x0 = np.array([0.0, 0.0, 0.0])  # [m]
+    v0 = np.array([0.0, constants.c / gamma, 0.0])  # [m/s]
+    om_ce = q * B_0 / m  # [rad/s]
+    r_ce = np.linalg.norm(v0) / om_ce  # [m]
+    t_max = 2 * np.pi / om_ce  # one gyroperiod # [s]
+    steps = 100
+    dt = t_max / steps  # [s]
+
+    boris = ggcmpy.tracing.BorisIntegrator_python(emfields, q, m)
+    df = boris.integrate(x0, v0, t_max, dt)
+
+    assert len(df) == steps + 1
+
+    assert np.allclose(df.vx, np.sin(om_ce * df.time) * v0[1], atol=1e-2 * v0[1])
+    assert np.allclose(df.vy, np.cos(om_ce * df.time) * v0[1], atol=1e-2 * v0[1])
+    assert np.allclose(df.vz, 0.0)
+
+    assert np.allclose(df.x, r_ce * (1 - np.cos(om_ce * df.time)), atol=1e-2 * r_ce)
+    assert np.allclose(df.y, r_ce * (np.sin(om_ce * df.time)), atol=1e-2 * r_ce)
+    assert np.allclose(df.z, 0.0)
+
+
 @pytest.mark.parametrize(
     "Integrator",
     [
@@ -66,7 +95,7 @@ def test_interpolate():
     ],
 )
 def test_BorisIntegrator(Integrator):
-    """particle gyrating in a uniform magnetic field"""
+    """particle gyrating in a discretized uniform magnetic field"""
     q = constants.e  # [C]
     m = constants.m_e  # [kg]
     B_0 = 1e-8  # [T]


### PR DESCRIPTION
This pull request introduces support for integrating particle trajectories in a uniform electromagnetic field and improves the Boris integrator's flexibility. It also includes a new test for the uniform field case and minor documentation and metadata updates.

### Boris integrator improvements

* The `BorisIntegrator_python` class now accepts an `emfields.uniform` object in addition to the previous interpolator types, allowing for direct integration in a uniform field.

### New tests

* Added `test_BorisIntegrator_uniform` to verify correct particle gyration in a uniform magnetic field, ensuring the integrator works as expected for this case.

### Documentation and notebook updates

* Corrected variable names in the OpenGGCM tracing notebook: replaced `ex1`, `ey1`, `ez1` with `eflx`, `efly`, `eflz` to match the codebase and data variable conventions.
* Updated the kernel display name in the OpenGGCM tracing notebook metadata for clarity.