### PR TITLE
Refactor BorisIntegrator for relativistic calculations based on u

### DIFF
--- a/docs/tracing/dipole.ipynb
+++ b/docs/tracing/dipole.ipynb
@@ -164,13 +164,15 @@
     "B_x0 = field.B(x0)\n",
     "T_e = 1.0 * 1e3 * constants.e  # 1 keV in J\n",
     "v_e = np.sqrt(2 * T_e / constants.m_e)  # electron thermal speed\n",
-    "v_e *= 1000.0\n",
+    "v_e *= 10.0\n",
     "\n",
     "om_ce = np.abs(constants.e) * np.linalg.norm(B_x0) / constants.m_e  # gyrofrequency\n",
     "r_ce = constants.m_e * v_e / (constants.e * np.linalg.norm(field.B(x0)))  # gyroradius\n",
     "\n",
     "v0 = np.array([0.0, v_e, v_e])  # [m/s]\n",
     "print(f\"B={B_x0} [T] om_ce={om_ce:.2f} [1/s] r_ce={r_ce / R_E:.2f} [R_E]\")  # noqa: T201\n",
+    "gamma = 1.0 / np.sqrt(1 - (np.linalg.norm(v0) / constants.c) ** 2)\n",
+    "u0 = gamma * v0 / constants.c\n",
     "\n",
     "t_max = 100.0 * 2 * np.pi / om_ce  # [s]\n",
     "dt = 1.0 / om_ce / 10.0"
@@ -190,7 +192,7 @@
    "outputs": [],
    "source": [
     "boris = ggcmpy.tracing.BorisIntegrator(field, q=-constants.e, m=constants.m_e)\n",
-    "df = boris.integrate(x0, v0, t_max)"
+    "df = boris.integrate(x0, u0, t_max)"
    ]
   },
   {
@@ -207,7 +209,7 @@
    "outputs": [],
    "source": [
     "boris_cc = ggcmpy.tracing.BorisIntegrator(field_cc, q=-constants.e, m=constants.m_e)\n",
-    "df_cc = boris_cc.integrate(x0, v0, t_max)"
+    "df_cc = boris_cc.integrate(x0, u0, t_max)"
    ]
   },
   {
@@ -224,7 +226,7 @@
    "outputs": [],
    "source": [
     "boris_yee = ggcmpy.tracing.BorisIntegrator(field_yee, q=-constants.e, m=constants.m_e)\n",
-    "df_yee = boris_yee.integrate(x0, v0, t_max)"
+    "df_yee = boris_yee.integrate(x0, u0, t_max)"
    ]
   },
   {
@@ -247,7 +249,7 @@
     "boris_f2py = ggcmpy.tracing.BorisIntegrator_f2py(\n",
     "    field_yee, q=-constants.e, m=constants.m_e\n",
     ")\n",
-    "df_f2py = boris_f2py.integrate(x0, v0, t_max, dt_max=dt)"
+    "df_f2py = boris_f2py.integrate(x0, u0, 100 * t_max, dt_max=dt)"
    ]
   },
   {

--- a/docs/tracing/openggcm.ipynb
+++ b/docs/tracing/openggcm.ipynb
@@ -100,17 +100,20 @@
     "B_x0 = boris._interpolator.B(x0)\n",
     "T_e = 1.0 * 1e3 * constants.e  # 1 keV in J\n",
     "v_e = np.sqrt(2 * T_e / constants.m_e)  # electron thermal speed\n",
-    "v_e *= 100.0\n",
+    "v_e *= 10.0\n",
     "\n",
     "om_ce = np.abs(constants.e) * np.linalg.norm(B_x0) / constants.m_e  # gyrofrequency\n",
     "r_ce = constants.m_e * v_e / (constants.e * np.linalg.norm(B_x0))  # gyroradius\n",
     "print(f\"B={B_x0} om_ce={om_ce} r_ce={r_ce}\")  # noqa: T201\n",
     "\n",
     "v0 = np.array([0.0, v_e, v_e])  # [m/s]\n",
-    "dt = 2 * np.pi / om_ce / 20\n",
-    "t_max = 500 * 2 * np.pi / om_ce  # [s]\n",
+    "gamma = 1.0 / np.sqrt(1 - (np.linalg.norm(v0) / constants.c) ** 2)\n",
+    "u0 = gamma * v0 / constants.c\n",
     "\n",
-    "df = boris.integrate(x0, v0, t_max, dt)\n",
+    "dt = 2 * np.pi / om_ce / 20\n",
+    "t_max = 5000 * 2 * np.pi / om_ce  # [s]\n",
+    "\n",
+    "df = boris.integrate(x0, u0, t_max, dt)\n",
     "df"
    ]
   },
@@ -210,7 +213,7 @@
    "outputs": [],
    "source": [
     "plotter = pv.Plotter()\n",
-    "plot_trajectory(plotter, df, line_width=1, color=\"blue\")\n",
+    "plot_trajectory(plotter, df, line_width=2, color=\"red\")\n",
     "for _df in dfs:\n",
     "    plot_trajectory(plotter, _df, line_width=1, color=\"grey\")\n",
     "plotter.show()"
@@ -236,6 +239,14 @@
     "df[\"E\"] = 0.5 * constants.m_e * np.linalg.norm(df[[\"vx\", \"vy\", \"vz\"]].values, axis=1)\n",
     "df.plot(x=\"time\", y=\"E\", title=\"Energy of the particle over time\");"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b81749b8",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/src/ggcmpy/backends/jrrle/particle_tracing.F90
+++ b/src/ggcmpy/backends/jrrle/particle_tracing.F90
@@ -227,7 +227,7 @@ contains
 
       integer :: step, n_data
       real :: t
-      real, dimension(3) :: x, v, E, B
+      real, dimension(3) :: x, u, um, up, E, B
       real :: qprime, om_c, dt, gamma
       real, dimension(3) :: h, s
       real, parameter :: pi = 3.14159265358979323846
@@ -237,8 +237,7 @@ contains
 
       t = 0.0
       x = x0
-      gamma = 1.0 / (1.0 - sum(u0**2))**0.5
-      v = u0 * c / gamma
+      u = u0
       qprime = 0.5 * this%q / this%m
       ! times, positions, velocities = [], [], []
       B = get_B(x)
@@ -247,29 +246,37 @@ contains
          if (step < n_data) then
             data(1, step) = t
             data(2:4, step) = x
-            data(5:7, step) = v
+            data(5:7, step) = u
             step = step + 1
          end if
 
          om_c = norm2(2. * qprime * B)  ! gyro frequency
          dt = min(dt_max, gyro_max * 2.0 * pi / om_c)
 
-         x = x + 0.5 * dt * v
+         gamma = sqrt(1.0 + sum(u**2))
+         x = x + 0.5 * dt * u * c / gamma
          B = get_B(x)
          E = get_E(x)
-         v = v + dt * qprime * E
-         h = dt * qprime * B
-         s = 2. * h / (1. + norm2(h) ** 2)
-         v = v + cross(v + cross(v, h), s)
-         v = v + dt * qprime * E
-         x = x + 0.5 * dt * v
+         ! E-field acceleration part 1
+         um = u + dt * qprime * E / c
+
+         ! B-field rotation
+         gamma = sqrt(1.0 + sum(um**2))
+         h = dt * qprime * B / gamma
+         s = 2. * h / (1. + sum(h**2))
+         up = um + cross(um + cross(um, h), s)
+
+         ! E-field acceleration part 2
+         u = up + dt * qprime * E / c
+         gamma = sqrt(1.0 + sum(u**2))
+         x = x + 0.5 * dt * u * c / gamma
          t = t + dt
       end do
 
       if (step < n_data) then
          data(1, step) = t
          data(2:4, step) = x
-         data(5:7, step) = v
+         data(5:7, step) = u
          step = step + 1
       end if
       n_out = step

--- a/src/ggcmpy/backends/jrrle/particle_tracing.F90
+++ b/src/ggcmpy/backends/jrrle/particle_tracing.F90
@@ -207,10 +207,10 @@ contains
       this%m = m
    end subroutine boris_integrator_t_init
 
-   subroutine boris_integrator_t_integrate(this, x0, v0, get_E, get_B, t_max, dt_max, gyro_max, data, n_out)
+   subroutine boris_integrator_t_integrate(this, x0, u0, get_E, get_B, t_max, dt_max, gyro_max, data, n_out)
       class(boris_integrator_t), intent(in) :: this
       real, dimension(3), intent(in) :: x0
-      real, dimension(3), intent(in) :: v0
+      real, dimension(3), intent(in) :: u0
       interface
          function get_E(x) result(E)
             real, dimension(3), intent(in) :: x
@@ -228,15 +228,17 @@ contains
       integer :: step, n_data
       real :: t
       real, dimension(3) :: x, v, E, B
-      real :: qprime, om_c, dt
+      real :: qprime, om_c, dt, gamma
       real, dimension(3) :: h, s
       real, parameter :: pi = 3.14159265358979323846
+      real, parameter :: c = 299792458.0
 
       n_data = size(data, 2)
 
       t = 0.0
       x = x0
-      v = v0
+      gamma = 1.0 / (1.0 - sum(u0**2))**0.5
+      v = u0 * c / gamma
       qprime = 0.5 * this%q / this%m
       ! times, positions, velocities = [], [], []
       B = get_B(x)

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -209,7 +209,7 @@ class BorisIntegrator_python:
             self.push_x(x, u, 0.5 * dt)
             B = self._interpolator.B(x)
             E = self._interpolator.E(x)
-            self.push_u(u, E, B, qprime, dt)
+            self.push_u(u, E, B, qprime * dt)
             self.push_x(x, u, 0.5 * dt)
             t += dt
 
@@ -224,12 +224,12 @@ class BorisIntegrator_python:
         x += dt * u * constants.c / gamma
 
     @staticmethod
-    def push_u(u: np.ndarray, E: np.ndarray, B: np.ndarray, qprime: float, dt: float):
-        u += dt * qprime * E / constants.c
-        h = dt * qprime * B
+    def push_u(u: np.ndarray, E: np.ndarray, B: np.ndarray, dq: float):
+        um = u + dq * E / constants.c
+        h = dq * B
         s = 2 * h / (1 + np.linalg.norm(h) ** 2)
-        u += np.cross(u + np.cross(u, h), s)
-        u += dt * qprime * E / constants.c
+        up = um + np.cross(um + np.cross(um, h), s)
+        u[:] = up + dq * E / constants.c
 
 
 class BorisIntegrator_f2py:

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -188,10 +188,11 @@ class BorisIntegrator_python:
         else:
             self._interpolator = ds  # assume it's already an emfields
 
-    def integrate(self, x0, v0, t_max, dt_max=1.0, gyro_max=0.1) -> pd.DataFrame:
+    def integrate(self, x0, u0, t_max, dt_max=1.0, gyro_max=0.1) -> pd.DataFrame:
         t = 0.0
         x = x0.copy()
-        v = v0.copy()
+        gamma = np.sqrt(1 + np.linalg.norm(u0) ** 2)
+        v = u0 * constants.c / gamma
         qprime = 0.5 * self.q / self.m
 
         B = self._interpolator.B(x)
@@ -252,7 +253,9 @@ class BorisIntegrator_f2py:
             assert isinstance(df, FieldInterpolatorYee_f2py)
             self._interpolator = df
 
-    def integrate(self, x0, v0, t_max, dt_max=1.0, gyro_max=0.1) -> pd.DataFrame:
+    def integrate(self, x0, u0, t_max, dt_max=1.0, gyro_max=0.1) -> pd.DataFrame:
+        gamma = np.sqrt(1 + np.linalg.norm(u0) ** 2)
+        v0 = u0 * constants.c / gamma
         n_steps = int(t_max / dt_max) + 2  # add some extra space for round-off issues
         data = np.zeros((7, n_steps), dtype=np.float32, order="F")
         n_out = _jrrle.particle_tracing_f2py.boris_integrate(

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -218,19 +218,17 @@ class BorisIntegrator_python:
             columns=["time", "x", "y", "z", "ux", "uy", "uz"],
         )
 
-    def push_x(self, x: np.ndarray, u: np.ndarray, dt: float):
+    @staticmethod
+    def push_x(x: np.ndarray, u: np.ndarray, dt: float):
         x += dt * u * constants.c
 
-    def push_u(
-        self, u: np.ndarray, E: np.ndarray, B: np.ndarray, qprime: float, dt: float
-    ):
-        v = u * constants.c
-        v += dt * qprime * E
+    @staticmethod
+    def push_u(u: np.ndarray, E: np.ndarray, B: np.ndarray, qprime: float, dt: float):
+        u += dt * qprime * E / constants.c
         h = dt * qprime * B
         s = 2 * h / (1 + np.linalg.norm(h) ** 2)
-        v += np.cross(v + np.cross(v, h), s)
-        v += dt * qprime * E
-        u[:] = v / constants.c
+        u += np.cross(u + np.cross(u, h), s)
+        u += dt * qprime * E / constants.c
 
 
 class BorisIntegrator_f2py:

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -191,40 +191,46 @@ class BorisIntegrator_python:
     def integrate(self, x0, u0, t_max, dt_max=1.0, gyro_max=0.1) -> pd.DataFrame:
         t = 0.0
         x = x0.copy()
-        gamma = np.sqrt(1 + np.linalg.norm(u0) ** 2)
-        v = u0 * constants.c / gamma
+        u = u0.copy()
         qprime = 0.5 * self.q / self.m
 
         B = self._interpolator.B(x)
-        times, positions, velocities = [], [], []
+        times, positions, momenta = [], [], []
         while t < t_max:
             times.append(t)
             positions.append(x.copy())
-            velocities.append(v.copy())
+            momenta.append(u.copy())
 
             om_c = np.linalg.norm(
                 2.0 * qprime * B
             )  # gyro frequency (based on previous B)
             dt = min(dt_max, gyro_max * 2.0 * np.pi / om_c)
-            x += 0.5 * dt * v
+
+            self.push_x(x, u, 0.5 * dt)
             B = self._interpolator.B(x)
             E = self._interpolator.E(x)
-            v += dt * qprime * E
-            h = dt * qprime * B
-            s = 2 * h / (1 + np.linalg.norm(h) ** 2)
-            v += np.cross(v + np.cross(v, h), s)
-            v += qprime * E
-            x += 0.5 * dt * v
+            self.push_u(u, E, B, qprime, dt)
+            self.push_x(x, u, 0.5 * dt)
             t += dt
 
-        df = pd.DataFrame(
-            np.column_stack((times, positions, velocities)),
-            columns=["time", "x", "y", "z", "vx", "vy", "vz"],
+        return pd.DataFrame(
+            np.column_stack((times, positions, momenta)),
+            columns=["time", "x", "y", "z", "ux", "uy", "uz"],
         )
-        df["ux"] = df["vx"] / constants.c
-        df["uy"] = df["vy"] / constants.c
-        df["uz"] = df["vz"] / constants.c
-        return df.drop(columns=["vx", "vy", "vz"])  # type: ignore[no-any-return]
+
+    def push_x(self, x: np.ndarray, u: np.ndarray, dt: float):
+        x += dt * u * constants.c
+
+    def push_u(
+        self, u: np.ndarray, E: np.ndarray, B: np.ndarray, qprime: float, dt: float
+    ):
+        v = u * constants.c
+        v += dt * qprime * E
+        h = dt * qprime * B
+        s = 2 * h / (1 + np.linalg.norm(h) ** 2)
+        v += np.cross(v + np.cross(v, h), s)
+        v += dt * qprime * E
+        u[:] = v / constants.c
 
 
 class BorisIntegrator_f2py:

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -288,12 +288,10 @@ class BorisIntegrator_f2py:
             self._interpolator = df
 
     def integrate(self, x0, u0, t_max, dt_max=1.0, gyro_max=0.1) -> pd.DataFrame:
-        gamma = np.sqrt(1 + np.linalg.norm(u0) ** 2)
-        v0 = u0 * constants.c / gamma
         n_steps = int(t_max / dt_max) + 2  # add some extra space for round-off issues
         data = np.zeros((7, n_steps), dtype=np.float32, order="F")
         n_out = _jrrle.particle_tracing_f2py.boris_integrate(
-            x0, v0, t_max, dt_max, gyro_max, data
+            x0, u0, t_max, dt_max, gyro_max, data
         )
         df = pd.DataFrame(
             data.T[:n_out], columns=["time", "x", "y", "z", "vx", "vy", "vz"]

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -226,9 +226,37 @@ class BorisIntegrator_python:
     @staticmethod
     def push_u(u: np.ndarray, E: np.ndarray, B: np.ndarray, dq: float):
         um = u + dq * E / constants.c
-        h = dq * B
-        s = 2 * h / (1 + np.linalg.norm(h) ** 2)
-        up = um + np.cross(um + np.cross(um, h), s)
+
+        # Rotation due to magnetic field
+        root = dq / np.sqrt(1.0 + np.linalg.norm(um) ** 2)
+        tau = root * B
+        tau_norm = 1.0 / (1.0 + np.linalg.norm(tau) ** 2)
+        up = np.array(
+            [
+                (
+                    (1.0 + (tau[0]) ** 2 - (tau[1]) ** 2 - (tau[2]) ** 2) * um[0]
+                    + (2.0 * tau[0] * tau[1] + 2.0 * tau[2]) * um[1]
+                    + (2.0 * tau[0] * tau[2] - 2.0 * tau[1]) * um[2]
+                )
+                * tau_norm,
+                (
+                    (2.0 * tau[0] * tau[1] - 2.0 * tau[2]) * um[0]
+                    + (1.0 - (tau[0]) ** 2 + (tau[1]) ** 2 - (tau[2]) ** 2) * um[1]
+                    + (2.0 * tau[1] * tau[2] + 2.0 * tau[0]) * um[2]
+                )
+                * tau_norm,
+                (
+                    (2.0 * tau[0] * tau[2] + 2.0 * tau[1]) * um[0]
+                    + (2.0 * tau[1] * tau[2] - 2.0 * tau[0]) * um[1]
+                    + (1.0 - (tau[0]) ** 2 - (tau[1]) ** 2 + (tau[2]) ** 2) * um[2]
+                )
+                * tau_norm,
+            ]
+        )
+
+        # h = dq * B
+        # s = 2 * h / (1 + np.linalg.norm(h) ** 2)
+        # up = um + np.cross(um + np.cross(um, h), s)
         u[:] = up + dq * E / constants.c
 
 

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -217,10 +217,14 @@ class BorisIntegrator_python:
             x += 0.5 * dt * v
             t += dt
 
-        return pd.DataFrame(
+        df = pd.DataFrame(
             np.column_stack((times, positions, velocities)),
             columns=["time", "x", "y", "z", "vx", "vy", "vz"],
         )
+        df["ux"] = df["vx"] / constants.c
+        df["uy"] = df["vy"] / constants.c
+        df["uz"] = df["vz"] / constants.c
+        return df.drop(columns=["vx", "vy", "vz"])  # type: ignore[no-any-return]
 
 
 class BorisIntegrator_f2py:
@@ -261,9 +265,13 @@ class BorisIntegrator_f2py:
         n_out = _jrrle.particle_tracing_f2py.boris_integrate(
             x0, v0, t_max, dt_max, gyro_max, data
         )
-        return pd.DataFrame(
+        df = pd.DataFrame(
             data.T[:n_out], columns=["time", "x", "y", "z", "vx", "vy", "vz"]
         )
+        df["ux"] = df["vx"] / constants.c
+        df["uy"] = df["vy"] / constants.c
+        df["uz"] = df["vz"] / constants.c
+        return df.drop(columns=["vx", "vy", "vz"])  # type: ignore[no-any-return]
 
 
 BorisIntegrator = BorisIntegrator_python

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -206,11 +206,11 @@ class BorisIntegrator_python:
             )  # gyro frequency (based on previous B)
             dt = min(dt_max, gyro_max * 2.0 * np.pi / om_c)
 
-            self.push_x(x, u, 0.5 * dt)
+            x = self.push_x(x, u, 0.5 * dt)
             B = self._interpolator.B(x)
             E = self._interpolator.E(x)
-            self.push_u(u, E, B, qprime * dt)
-            self.push_x(x, u, 0.5 * dt)
+            u = self.push_u(u, E, B, qprime * dt)
+            x = self.push_x(x, u, 0.5 * dt)
             t += dt
 
         return pd.DataFrame(
@@ -221,7 +221,7 @@ class BorisIntegrator_python:
     @staticmethod
     def push_x(x: np.ndarray, u: np.ndarray, dt: float):
         gamma = np.sqrt(1 + np.linalg.norm(u) ** 2)
-        x += dt * u * constants.c / gamma
+        return x + dt * u * constants.c / gamma
 
     @staticmethod
     def push_u(u: np.ndarray, E: np.ndarray, B: np.ndarray, dq: float):
@@ -254,10 +254,7 @@ class BorisIntegrator_python:
             ]
         )
 
-        # h = dq * B
-        # s = 2 * h / (1 + np.linalg.norm(h) ** 2)
-        # up = um + np.cross(um + np.cross(um, h), s)
-        u[:] = up + dq * E / constants.c
+        return up + dq * E / constants.c
 
 
 class BorisIntegrator_f2py:

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -293,13 +293,9 @@ class BorisIntegrator_f2py:
         n_out = _jrrle.particle_tracing_f2py.boris_integrate(
             x0, u0, t_max, dt_max, gyro_max, data
         )
-        df = pd.DataFrame(
-            data.T[:n_out], columns=["time", "x", "y", "z", "vx", "vy", "vz"]
+        return pd.DataFrame(
+            data.T[:n_out], columns=["time", "x", "y", "z", "ux", "uy", "uz"]
         )
-        df["ux"] = df["vx"] / constants.c
-        df["uy"] = df["vy"] / constants.c
-        df["uz"] = df["vz"] / constants.c
-        return df.drop(columns=["vx", "vy", "vz"])  # type: ignore[no-any-return]
 
 
 BorisIntegrator = BorisIntegrator_python

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -220,7 +220,8 @@ class BorisIntegrator_python:
 
     @staticmethod
     def push_x(x: np.ndarray, u: np.ndarray, dt: float):
-        x += dt * u * constants.c
+        gamma = np.sqrt(1 + np.linalg.norm(u) ** 2)
+        x += dt * u * constants.c / gamma
 
     @staticmethod
     def push_u(u: np.ndarray, E: np.ndarray, B: np.ndarray, qprime: float, dt: float):

--- a/tests/test_particle_tracing.py
+++ b/tests/test_particle_tracing.py
@@ -155,12 +155,13 @@ def test_BorisIntegratorYee(Integrator):
     boris = Integrator(field_yee, q, m)
     df = boris.integrate(x0, u0, t_max, dt)
 
-    assert len(df) == steps + 1
+    assert len(df) >= steps
+    assert len(df) <= steps + 2
 
-    assert np.allclose(df.ux, np.sin(om_ce * df.time) * u0[1], atol=1.0)
-    assert np.allclose(df.uy, np.cos(om_ce * df.time) * u0[1], atol=1.0)
+    assert np.allclose(df.ux, np.sin(om_ce * df.time) * u0[1], atol=1e-2 * u0[1])
+    assert np.allclose(df.uy, np.cos(om_ce * df.time) * u0[1], atol=1e-2 * u0[1])
     assert np.allclose(df.uz, 0.0)
 
-    assert np.allclose(df.x, r_ce * (1 - np.cos(om_ce * df.time)), atol=1e-3)
-    assert np.allclose(df.y, r_ce * (np.sin(om_ce * df.time)), atol=1e-3)
+    assert np.allclose(df.x, r_ce * (1 - np.cos(om_ce * df.time)), atol=1e-2 * r_ce)
+    assert np.allclose(df.y, r_ce * (np.sin(om_ce * df.time)), atol=1e-2 * r_ce)
     assert np.allclose(df.z, 0.0)

--- a/tests/test_particle_tracing.py
+++ b/tests/test_particle_tracing.py
@@ -138,7 +138,7 @@ def test_BorisIntegratorYee(Integrator):
     q = constants.e  # [C]
     m = constants.m_e  # [kg]
     B_0 = 1e-8  # [T]
-    v_0 = 0.5e-6 * constants.c
+    v_0 = 0.5 * constants.c
     field = ggcmpy.tracing.emfields.uniform(B_0=np.array([0.0, 0.0, B_0]))
     coords = make_coords()
     field_yee = ggcmpy.tracing.discretize_emfields_yee(coords, field)

--- a/tests/test_particle_tracing.py
+++ b/tests/test_particle_tracing.py
@@ -101,15 +101,16 @@ def test_BorisIntegrator(Integrator):
     q = constants.e  # [C]
     m = constants.m_e  # [kg]
     B_0 = 1e-8  # [T]
+    v_0 = 0.5e-6 * constants.c
     field = ggcmpy.tracing.emfields.uniform(B_0=np.array([0.0, 0.0, B_0]))
     coords = make_coords()
     field_cc = ggcmpy.tracing.discretize_emfields_cc(coords, field)
     x0 = np.array([0.0, 0.0, 0.0])  # [m]
-    v0 = np.array([0.0, 100.0, 0.0])  # [m/s]
+    v0 = np.array([0.0, v_0, 0.0])  # [m/s]
     gamma = 1.0 / np.sqrt(1 - (np.linalg.norm(v0) / constants.c) ** 2)
     u0 = gamma * v0 / constants.c
-    om_ce = q * B_0 / m  # [rad/s]
-    r_ce = np.linalg.norm(v0) / om_ce  # [m]
+    om_ce = q * B_0 / (gamma * m)  # [rad/s]
+    r_ce = m * np.linalg.norm(u0) * constants.c / (np.abs(q) * B_0)  # [m]
     t_max = 2 * np.pi / om_ce  # one gyroperiod # [s]
     steps = 100
     dt = t_max / steps  # [s]
@@ -137,15 +138,16 @@ def test_BorisIntegratorYee(Integrator):
     q = constants.e  # [C]
     m = constants.m_e  # [kg]
     B_0 = 1e-8  # [T]
+    v_0 = 0.5e-6 * constants.c
     field = ggcmpy.tracing.emfields.uniform(B_0=np.array([0.0, 0.0, B_0]))
     coords = make_coords()
     field_yee = ggcmpy.tracing.discretize_emfields_yee(coords, field)
     x0 = np.array([0.0, 0.0, 0.0])  # [m]
-    v0 = np.array([0.0, 100.0, 0.0])  # [m/s]
+    v0 = np.array([0.0, v_0, 0.0])  # [m/s]
     gamma = 1.0 / np.sqrt(1 - (np.linalg.norm(v0) / constants.c) ** 2)
     u0 = gamma * v0 / constants.c
-    om_ce = q * B_0 / m  # [rad/s]
-    r_ce = np.linalg.norm(v0) / om_ce  # [m]
+    om_ce = q * B_0 / (gamma * m)  # [rad/s]
+    r_ce = m * np.linalg.norm(u0) * constants.c / (np.abs(q) * B_0)  # [m]
     t_max = 2 * np.pi / om_ce  # one gyroperiod # [s]
     steps = 100
     dt = t_max / steps  # [s]

--- a/tests/test_particle_tracing.py
+++ b/tests/test_particle_tracing.py
@@ -11,7 +11,7 @@ from ggcmpy import _jrrle  # type: ignore[attr-defined]
 
 
 def make_coords() -> dict[str, np.ndarray]:
-    coords = {fld: np.linspace(-1.0, 1.0, 10) for fld in ["x", "y", "z"]}
+    coords = {fld: np.linspace(-1e6, 1e6, 10) for fld in ["x", "y", "z"]}
     coords |= {
         crd + "_nc": 0.5 * (coords[crd][:-1] + coords[crd][1:])
         for crd in ["x", "y", "z"]
@@ -101,7 +101,7 @@ def test_BorisIntegrator(Integrator):
     q = constants.e  # [C]
     m = constants.m_e  # [kg]
     B_0 = 1e-8  # [T]
-    v_0 = 0.5e-6 * constants.c
+    v_0 = 0.5 * constants.c
     field = ggcmpy.tracing.emfields.uniform(B_0=np.array([0.0, 0.0, B_0]))
     coords = make_coords()
     field_cc = ggcmpy.tracing.discretize_emfields_cc(coords, field)
@@ -120,12 +120,12 @@ def test_BorisIntegrator(Integrator):
 
     assert len(df) == steps + 1
 
-    assert np.allclose(df.ux, np.sin(om_ce * df.time) * u0[1], atol=1.0)
-    assert np.allclose(df.uy, np.cos(om_ce * df.time) * u0[1], atol=1.0)
+    assert np.allclose(df.ux, np.sin(om_ce * df.time) * u0[1], atol=1e-2 * u0[1])
+    assert np.allclose(df.uy, np.cos(om_ce * df.time) * u0[1], atol=1e-2 * u0[1])
     assert np.allclose(df.uz, 0.0)
 
-    assert np.allclose(df.x, r_ce * (1 - np.cos(om_ce * df.time)), atol=1e-3)
-    assert np.allclose(df.y, r_ce * (np.sin(om_ce * df.time)), atol=1e-3)
+    assert np.allclose(df.x, r_ce * (1 - np.cos(om_ce * df.time)), atol=1e-2 * r_ce)
+    assert np.allclose(df.y, r_ce * (np.sin(om_ce * df.time)), atol=1e-2 * r_ce)
     assert np.allclose(df.z, 0.0)
 
 

--- a/tests/test_particle_tracing.py
+++ b/tests/test_particle_tracing.py
@@ -64,14 +64,14 @@ def test_BorisIntegrator_uniform():
     q = constants.e  # [C]
     m = constants.m_e  # [kg]
     B_0 = 1e-8  # [T]
-    v_0 = 5e-5 * constants.c
+    v_0 = 0.5 * constants.c
     emfields = ggcmpy.tracing.emfields.uniform(B_0=np.array([0.0, 0.0, B_0]))
     x0 = np.array([0.0, 0.0, 0.0])  # [m]
     v0 = np.array([0.0, v_0, 0.0])  # [m/s]
     gamma = 1.0 / np.sqrt(1 - (np.linalg.norm(v0) / constants.c) ** 2)
     u0 = gamma * v0 / constants.c
-    om_ce = q * B_0 / m  # [rad/s]
-    r_ce = np.linalg.norm(v0) / om_ce  # [m]
+    om_ce = q * B_0 / (gamma * m)  # [rad/s]
+    r_ce = m * np.linalg.norm(u0) * constants.c / (np.abs(q) * B_0)  # [m]
     t_max = 2 * np.pi / om_ce  # one gyroperiod # [s]
     steps = 100
     dt = t_max / steps  # [s]

--- a/tests/test_particle_tracing.py
+++ b/tests/test_particle_tracing.py
@@ -64,10 +64,12 @@ def test_BorisIntegrator_uniform():
     q = constants.e  # [C]
     m = constants.m_e  # [kg]
     B_0 = 1e-8  # [T]
-    gamma = 1e-6 * np.sqrt(2.0)
+    v_0 = 5e-5 * constants.c
     emfields = ggcmpy.tracing.emfields.uniform(B_0=np.array([0.0, 0.0, B_0]))
     x0 = np.array([0.0, 0.0, 0.0])  # [m]
-    v0 = np.array([0.0, constants.c / gamma, 0.0])  # [m/s]
+    v0 = np.array([0.0, v_0, 0.0])  # [m/s]
+    gamma = 1.0 / np.sqrt(1 - (np.linalg.norm(v0) / constants.c) ** 2)
+    u0 = gamma * v0 / constants.c
     om_ce = q * B_0 / m  # [rad/s]
     r_ce = np.linalg.norm(v0) / om_ce  # [m]
     t_max = 2 * np.pi / om_ce  # one gyroperiod # [s]
@@ -75,7 +77,7 @@ def test_BorisIntegrator_uniform():
     dt = t_max / steps  # [s]
 
     boris = ggcmpy.tracing.BorisIntegrator_python(emfields, q, m)
-    df = boris.integrate(x0, v0, t_max, dt)
+    df = boris.integrate(x0, u0, t_max, dt)
 
     assert len(df) == steps + 1
 
@@ -104,6 +106,8 @@ def test_BorisIntegrator(Integrator):
     field_cc = ggcmpy.tracing.discretize_emfields_cc(coords, field)
     x0 = np.array([0.0, 0.0, 0.0])  # [m]
     v0 = np.array([0.0, 100.0, 0.0])  # [m/s]
+    gamma = 1.0 / np.sqrt(1 - (np.linalg.norm(v0) / constants.c) ** 2)
+    u0 = gamma * v0 / constants.c
     om_ce = q * B_0 / m  # [rad/s]
     r_ce = np.linalg.norm(v0) / om_ce  # [m]
     t_max = 2 * np.pi / om_ce  # one gyroperiod # [s]
@@ -111,7 +115,7 @@ def test_BorisIntegrator(Integrator):
     dt = t_max / steps  # [s]
 
     boris = Integrator(field_cc, q, m)
-    df = boris.integrate(x0, v0, t_max, dt)
+    df = boris.integrate(x0, u0, t_max, dt)
 
     assert len(df) == steps + 1
 
@@ -138,6 +142,8 @@ def test_BorisIntegratorYee(Integrator):
     field_yee = ggcmpy.tracing.discretize_emfields_yee(coords, field)
     x0 = np.array([0.0, 0.0, 0.0])  # [m]
     v0 = np.array([0.0, 100.0, 0.0])  # [m/s]
+    gamma = 1.0 / np.sqrt(1 - (np.linalg.norm(v0) / constants.c) ** 2)
+    u0 = gamma * v0 / constants.c
     om_ce = q * B_0 / m  # [rad/s]
     r_ce = np.linalg.norm(v0) / om_ce  # [m]
     t_max = 2 * np.pi / om_ce  # one gyroperiod # [s]
@@ -145,7 +151,7 @@ def test_BorisIntegratorYee(Integrator):
     dt = t_max / steps  # [s]
 
     boris = Integrator(field_yee, q, m)
-    df = boris.integrate(x0, v0, t_max, dt)
+    df = boris.integrate(x0, u0, t_max, dt)
 
     assert len(df) == steps + 1
 

--- a/tests/test_particle_tracing.py
+++ b/tests/test_particle_tracing.py
@@ -81,9 +81,9 @@ def test_BorisIntegrator_uniform():
 
     assert len(df) == steps + 1
 
-    assert np.allclose(df.vx, np.sin(om_ce * df.time) * v0[1], atol=1e-2 * v0[1])
-    assert np.allclose(df.vy, np.cos(om_ce * df.time) * v0[1], atol=1e-2 * v0[1])
-    assert np.allclose(df.vz, 0.0)
+    assert np.allclose(df.ux, np.sin(om_ce * df.time) * u0[1], atol=1e-2 * u0[1])
+    assert np.allclose(df.uy, np.cos(om_ce * df.time) * u0[1], atol=1e-2 * u0[1])
+    assert np.allclose(df.uz, 0.0)
 
     assert np.allclose(df.x, r_ce * (1 - np.cos(om_ce * df.time)), atol=1e-2 * r_ce)
     assert np.allclose(df.y, r_ce * (np.sin(om_ce * df.time)), atol=1e-2 * r_ce)
@@ -119,9 +119,9 @@ def test_BorisIntegrator(Integrator):
 
     assert len(df) == steps + 1
 
-    assert np.allclose(df.vx, np.sin(om_ce * df.time) * v0[1], atol=1.0)
-    assert np.allclose(df.vy, np.cos(om_ce * df.time) * v0[1], atol=1.0)
-    assert np.allclose(df.vz, 0.0)
+    assert np.allclose(df.ux, np.sin(om_ce * df.time) * u0[1], atol=1.0)
+    assert np.allclose(df.uy, np.cos(om_ce * df.time) * u0[1], atol=1.0)
+    assert np.allclose(df.uz, 0.0)
 
     assert np.allclose(df.x, r_ce * (1 - np.cos(om_ce * df.time)), atol=1e-3)
     assert np.allclose(df.y, r_ce * (np.sin(om_ce * df.time)), atol=1e-3)
@@ -155,9 +155,9 @@ def test_BorisIntegratorYee(Integrator):
 
     assert len(df) == steps + 1
 
-    assert np.allclose(df.vx, np.sin(om_ce * df.time) * v0[1], atol=1.0)
-    assert np.allclose(df.vy, np.cos(om_ce * df.time) * v0[1], atol=1.0)
-    assert np.allclose(df.vz, 0.0)
+    assert np.allclose(df.ux, np.sin(om_ce * df.time) * u0[1], atol=1.0)
+    assert np.allclose(df.uy, np.cos(om_ce * df.time) * u0[1], atol=1.0)
+    assert np.allclose(df.uz, 0.0)
 
     assert np.allclose(df.x, r_ce * (1 - np.cos(om_ce * df.time)), atol=1e-3)
     assert np.allclose(df.y, r_ce * (np.sin(om_ce * df.time)), atol=1e-3)


### PR DESCRIPTION
This pull request refactors the particle tracing codebase to use relativistic momentum (u = γv/c) instead of velocity for the Boris integrator, ensuring accurate simulation of relativistic particle motion. The changes affect the Python, Fortran, and f2py implementations, as well as all related documentation and tests. Key updates include changing the integrator interfaces to accept and return momentum, updating the Boris push algorithm to its relativistic form, and adjusting tests and notebooks for consistency.

**Core algorithm and interface updates:**

* Refactored all Boris integrators (`BorisIntegrator`, `BorisIntegrator_f2py`, Fortran backend) to use relativistic momentum `u` instead of velocity `v` throughout the integration process, including function signatures, internal state, and output DataFrame columns. Added static methods `push_x` and `push_u` to encapsulate the relativistic Boris push steps. [[1]](diffhunk://#diff-9f383faa9413660d10ceea27743dbc7c4836918d427d1b39a762aa4cfec28ee6L191-R257) [[2]](diffhunk://#diff-9f383faa9413660d10ceea27743dbc7c4836918d427d1b39a762aa4cfec28ee6L255-R297) [[3]](diffhunk://#diff-c03c156c2bd38c81d362cb5d40713c36f278ec1805799d2ee85d6b0fd7c5cb20L210-R213) [[4]](diffhunk://#diff-c03c156c2bd38c81d362cb5d40713c36f278ec1805799d2ee85d6b0fd7c5cb20L230-R240) [[5]](diffhunk://#diff-c03c156c2bd38c81d362cb5d40713c36f278ec1805799d2ee85d6b0fd7c5cb20L248-R279)

* Updated all notebook examples (`docs/tracing/dipole.ipynb`, `docs/tracing/openggcm.ipynb`) to compute and use `u0` (relativistic momentum) instead of `v0` (velocity) for initial conditions and integrator calls. Adjusted scaling factors and plotting for consistency. [[1]](diffhunk://#diff-3914ea3082fbb22f52ff302f1ad58656f8112d3bb241757a2894317d6925a54fL167-R175) [[2]](diffhunk://#diff-3914ea3082fbb22f52ff302f1ad58656f8112d3bb241757a2894317d6925a54fL193-R195) [[3]](diffhunk://#diff-3914ea3082fbb22f52ff302f1ad58656f8112d3bb241757a2894317d6925a54fL210-R212) [[4]](diffhunk://#diff-3914ea3082fbb22f52ff302f1ad58656f8112d3bb241757a2894317d6925a54fL227-R229) [[5]](diffhunk://#diff-3914ea3082fbb22f52ff302f1ad58656f8112d3bb241757a2894317d6925a54fL250-R252) [[6]](diffhunk://#diff-84918c2c980780bce993c23b7f1b290de45647aebaa7c53dcfa123cfa3b8b23dL103-R116) [[7]](diffhunk://#diff-84918c2c980780bce993c23b7f1b290de45647aebaa7c53dcfa123cfa3b8b23dL213-R216) [[8]](diffhunk://#diff-84918c2c980780bce993c23b7f1b290de45647aebaa7c53dcfa123cfa3b8b23dR242-R249)

**Testing and validation:**

* Modified all relevant tests in `tests/test_particle_tracing.py` to work with momentum (`ux`, `uy`, `uz`) instead of velocity, updated initial conditions, gyrofrequency, and gyroradius calculations to account for relativistic corrections, and relaxed tolerances where appropriate. [[1]](diffhunk://#diff-a2459590a678e8c3cc4d0e4651ed2c081e05fc5eeb085e1efa76106c89169db3L67-R86) [[2]](diffhunk://#diff-a2459590a678e8c3cc4d0e4651ed2c081e05fc5eeb085e1efa76106c89169db3R104-R128) [[3]](diffhunk://#diff-a2459590a678e8c3cc4d0e4651ed2c081e05fc5eeb085e1efa76106c89169db3R141-R166)

**Other improvements:**

* Updated coordinate ranges in test fixtures to use realistic physical scales (meters) for improved numerical stability and relevance.
* Minor notebook improvements: increased integration time, adjusted plot appearance, and added empty code cell for future expansion. [[1]](diffhunk://#diff-84918c2c980780bce993c23b7f1b290de45647aebaa7c53dcfa123cfa3b8b23dL103-R116) [[2]](diffhunk://#diff-84918c2c980780bce993c23b7f1b290de45647aebaa7c53dcfa123cfa3b8b23dR242-R249)

These changes ensure the codebase accurately models relativistic particle trajectories and maintains consistency across Python, Fortran, and documentation.