### PR TITLE
Implement C++ Boris algorithm with particle handling

### DIFF
--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
@@ -1,0 +1,72 @@
+
+#pragma once
+
+#include <openggcm/constants.hxx>
+#include <openggcm/emfields.hxx>
+#include <openggcm/tracing/particle.hxx>
+
+#include <functional>
+#include <string>
+
+namespace openggcm
+{
+
+namespace tracing
+{
+
+class boris
+{
+public:
+  boris(const emfields &emfields) : emfields_(emfields) {}
+
+  std::string repr() const
+  {
+    return "boris(emfields=" + emfields_.get().repr() + ")";
+  }
+
+  void push_x(particle &p, double dt) const { p.x += dt * p.v(); }
+
+  void push_v(particle &p, double dt) const
+  {
+    auto E = emfields_.get().E(p.x);
+    auto B = emfields_.get().B(p.x);
+
+    double dq = 0.5 * (p.q / p.m) * dt;
+    // Half acceleration due to electric field
+    double3 um = p.u + dq * E / constants::c;
+
+    // Rotation due to magnetic field
+    double root = dq / sqrt(1. + sqr(um[0]) + sqr(um[1]) + sqr(um[2]));
+    double3 tau = root * B;
+    double tau_norm = 1. / (1. + sqr(tau[0]) + sqr(tau[1]) + sqr(tau[2]));
+    double3 up;
+    up[0] = ((1. + sqr(tau[0]) - sqr(tau[1]) - sqr(tau[2])) * um[0] +
+             (2. * tau[0] * tau[1] + 2. * tau[2]) * um[1] +
+             (2. * tau[0] * tau[2] - 2. * tau[1]) * um[2]) *
+            tau_norm;
+    up[1] = ((2. * tau[0] * tau[1] - 2. * tau[2]) * um[0] +
+             (1. - sqr(tau[0]) + sqr(tau[1]) - sqr(tau[2])) * um[1] +
+             (2. * tau[1] * tau[2] + 2. * tau[0]) * um[2]) *
+            tau_norm;
+    up[2] = ((2. * tau[0] * tau[2] + 2. * tau[1]) * um[0] +
+             (2. * tau[1] * tau[2] - 2. * tau[0]) * um[1] +
+             (1. - sqr(tau[0]) - sqr(tau[1]) + sqr(tau[2])) * um[2]) *
+            tau_norm;
+
+    p.u = up + dq * E / constants::c;
+  }
+
+  void push(particle &p, double dt) const
+  {
+    push_x(p, .5 * dt);
+    push_v(p, dt);
+    push_x(p, .5 * dt);
+  }
+
+private:
+  std::reference_wrapper<const emfields>
+      emfields_; // FIXME lifetime issues with nanobind
+};
+
+} // namespace tracing
+} // namespace openggcm

--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
@@ -17,7 +17,10 @@ namespace tracing
 class boris
 {
 public:
-  boris(const emfields &emfields) : emfields_(emfields) {}
+  boris(const emfields &emfields, double q, double m)
+      : emfields_(emfields), q_(q), m_(m)
+  {
+  }
 
   std::string repr() const
   {
@@ -31,7 +34,7 @@ public:
     auto E = emfields_.get().E(p.x);
     auto B = emfields_.get().B(p.x);
 
-    double dq = 0.5 * (p.q / p.m) * dt;
+    double dq = 0.5 * (q_ / m_) * dt;
     // Half acceleration due to electric field
     double3 um = p.u + dq * E / constants::c;
 
@@ -59,7 +62,7 @@ public:
   void push(particle &prt, double t_max, double dt_max, double gyro_max,
             particles &prts) const
   {
-    double qprime = 0.5 * prt.q / prt.m;
+    double qprime = 0.5 * q_ / m_;
     double3 B = emfields_.get().B(prt.x);
     double om_c = 2.0 * std::abs(qprime) * norm(B);
     double dt = std::min(dt_max, gyro_max * 2.0 * constants::pi / om_c);
@@ -80,6 +83,7 @@ public:
 private:
   std::reference_wrapper<const emfields>
       emfields_; // FIXME potential lifetime issues with nanobind
+  double q_, m_;
 };
 
 } // namespace tracing

--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
@@ -27,16 +27,20 @@ public:
     return "boris(emfields=" + emfields_.get().repr() + ")";
   }
 
-  void push_x(particle &p, double dt) const { p.x += dt * p.v(); }
-
-  void push_u(particle &p, double dt) const
+  void push_x(double3 &x, double3 &u, double dt) const
   {
-    auto E = emfields_.get().E(p.x);
-    auto B = emfields_.get().B(p.x);
+    double inv_gamma = 1. / std::sqrt(1.0 + norm2(u));
+    x += dt * u * inv_gamma * constants::c;
+  }
+
+  void push_u(double3 &x, double3 &u, double dt) const
+  {
+    auto E = emfields_.get().E(x);
+    auto B = emfields_.get().B(x);
 
     double dq = 0.5 * (q_ / m_) * dt;
     // Half acceleration due to electric field
-    double3 um = p.u + dq * E / constants::c;
+    double3 um = u + dq * E / constants::c;
 
     // Rotation due to magnetic field
     double root = dq / sqrt(1. + sqr(um[0]) + sqr(um[1]) + sqr(um[2]));
@@ -56,7 +60,7 @@ public:
              (1. - sqr(tau[0]) - sqr(tau[1]) + sqr(tau[2])) * um[2]) *
             tau_norm;
 
-    p.u = up + dq * E / constants::c;
+    u = up + dq * E / constants::c;
   }
 
   void push(particle &prt, double t_max, double dt_max, double gyro_max,
@@ -72,9 +76,9 @@ public:
 
     while (t < t_max)
     {
-      push_x(prt, .5 * dt);
-      push_u(prt, dt);
-      push_x(prt, .5 * dt);
+      push_x(prt.x, prt.u, .5 * dt);
+      push_u(prt.x, prt.u, dt);
+      push_x(prt.x, prt.u, .5 * dt);
       t += dt;
       prts.add_particle(t, prt.x, prt.u);
     }

--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
@@ -56,19 +56,25 @@ public:
     p.u = up + dq * E / constants::c;
   }
 
-  void push(double t, particle &p, double dt_max, double gyro_max,
+  void push(particle &prt, double t_max, double dt_max, double gyro_max,
             particles &prts) const
   {
-    double qprime = 0.5 * p.q / p.m;
-    double3 B = emfields_.get().B(p.x);
+    double qprime = 0.5 * prt.q / prt.m;
+    double3 B = emfields_.get().B(prt.x);
     double om_c = 2.0 * std::abs(qprime) * norm(B);
     double dt = std::min(dt_max, gyro_max * 2.0 * constants::pi / om_c);
 
-    push_x(p, .5 * dt);
-    push_v(p, dt);
-    push_x(p, .5 * dt);
-    t += dt;
-    prts.add_particle(t, p.x, p.u);
+    double t = 0.;
+    prts.add_particle(t, prt.x, prt.u);
+
+    while (t < t_max)
+    {
+      push_x(prt, .5 * dt);
+      push_v(prt, dt);
+      push_x(prt, .5 * dt);
+      t += dt;
+      prts.add_particle(t, prt.x, prt.u);
+    }
   }
 
 private:

--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
@@ -56,8 +56,14 @@ public:
     p.u = up + dq * E / constants::c;
   }
 
-  void push(double t, particle &p, double dt, particles &prts) const
+  void push(double t, particle &p, double dt_max, double gyro_max,
+            particles &prts) const
   {
+    double qprime = 0.5 * p.q / p.m;
+    double3 B = emfields_.get().B(p.x);
+    double om_c = 2.0 * std::abs(qprime) * norm(B);
+    double dt = std::min(dt_max, gyro_max * 2.0 * constants::pi / om_c);
+
     push_x(p, .5 * dt);
     push_v(p, dt);
     push_x(p, .5 * dt);
@@ -67,7 +73,7 @@ public:
 
 private:
   std::reference_wrapper<const emfields>
-      emfields_; // FIXME lifetime issues with nanobind
+      emfields_; // FIXME potential lifetime issues with nanobind
 };
 
 } // namespace tracing

--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
@@ -29,7 +29,7 @@ public:
 
   void push_x(particle &p, double dt) const { p.x += dt * p.v(); }
 
-  void push_v(particle &p, double dt) const
+  void push_u(particle &p, double dt) const
   {
     auto E = emfields_.get().E(p.x);
     auto B = emfields_.get().B(p.x);
@@ -73,7 +73,7 @@ public:
     while (t < t_max)
     {
       push_x(prt, .5 * dt);
-      push_v(prt, dt);
+      push_u(prt, dt);
       push_x(prt, .5 * dt);
       t += dt;
       prts.add_particle(t, prt.x, prt.u);

--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
@@ -56,11 +56,13 @@ public:
     p.u = up + dq * E / constants::c;
   }
 
-  void push(particle &p, double dt) const
+  void push(double t, particle &p, double dt, particles &prts) const
   {
     push_x(p, .5 * dt);
     push_v(p, dt);
     push_x(p, .5 * dt);
+    t += dt;
+    prts.add_particle(t, p.x, p.u);
   }
 
 private:

--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/particle.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/particle.hxx
@@ -12,7 +12,7 @@ namespace tracing
 class particle
 {
 public:
-  particle(double3 x, double3 u, double q, double m) : x(x), u(u), q(q), m(m) {}
+  particle(double3 x, double3 u) : x(x), u(u) {}
 
   double3 v() const { return (constants::c / gamma()) * u; }
 
@@ -25,14 +25,11 @@ public:
   {
     return "particle(x=[" + std::to_string(x[0]) + ", " + std::to_string(x[1]) +
            ", " + std::to_string(x[2]) + "], u=[" + std::to_string(u[0]) +
-           ", " + std::to_string(u[1]) + ", " + std::to_string(u[2]) +
-           "], q=" + std::to_string(q) + ", m=" + std::to_string(m) + ")";
+           ", " + std::to_string(u[1]) + ", " + std::to_string(u[2]) + "])";
   }
 
   double3 x;
   double3 u;
-  double q;
-  double m;
 };
 
 class particles

--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/particle.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/particle.hxx
@@ -35,5 +35,27 @@ public:
   double m;
 };
 
+class particles
+{
+public:
+  void add_particle(double t, double3 r, double3 u)
+  {
+    t_.push_back(t);
+    r_.push_back(r);
+    u_.push_back(u);
+  }
+
+  std::tuple<std::vector<double>, std::vector<double3>, std::vector<double3>>
+  to_tuple() const
+  {
+    return std::make_tuple(t_, r_, u_);
+  }
+
+private:
+  std::vector<double> t_;
+  std::vector<double3> r_;
+  std::vector<double3> u_;
+};
+
 } // namespace tracing
 } // namespace openggcm

--- a/src/ggcmpy/libopenggcm/include/openggcm/util.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/util.hxx
@@ -16,6 +16,8 @@ inline double norm(double3 x)
   return std::sqrt(sqr(x[0]) + sqr(x[1]) + sqr(x[2]));
 }
 
+inline double norm2(double3 x) { return sqr(x[0]) + sqr(x[1]) + sqr(x[2]); }
+
 inline double dot(double3 x, double3 y)
 {
   return x[0] * y[0] + x[1] * y[1] + x[2] * y[2];

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -5,6 +5,7 @@
 #include <nanobind/stl/tuple.h>
 
 #include <openggcm/emfields.hxx>
+#include <openggcm/tracing/boris.hxx>
 #include <openggcm/tracing/particle.hxx>
 
 #include <nanobind/stl/detail/nb_array.h>
@@ -236,7 +237,8 @@ NB_MODULE(_openggcm, m)
       .def("__repr__", &emfields::repr);
 
   nb::class_<emfields_uniform, emfields>(m, "emfields_uniform")
-      .def(nb::init<double3, double3>(), "E_0"_a, "B_0"_a);
+      .def(nb::init<double3, double3>(), "E_0"_a = double3{0.0, 0.0, 0.0},
+           "B_0"_a = double3{0.0, 0.0, 0.0});
 
   nb::class_<emfields_dipole, emfields>(m, "emfields_dipole")
       .def(nb::init<double3>(), "m"_a);
@@ -276,4 +278,11 @@ NB_MODULE(_openggcm, m)
       .def_rw("u", &particle::u)
       .def_rw("q", &particle::q)
       .def_rw("m", &particle::m);
+
+  // ------------------------------------------------------------------
+  // boris
+  nb::class_<boris>(tracing, "boris")
+      .def(nb::init<const emfields &>(), "emfields"_a)
+      .def("__repr__", &boris::repr)
+      .def("push", &boris::push, "p"_a, "dt"_a);
 }

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -292,6 +292,6 @@ NB_MODULE(_openggcm, m)
   nb::class_<boris>(tracing, "boris")
       .def(nb::init<const emfields &>(), "emfields"_a)
       .def("__repr__", &boris::repr)
-      .def("push", &boris::push, "t"_a, "p"_a, "prts"_a, "dt_max"_a,
-           "gyro_max"_a);
+      .def("push", &boris::push, "prt"_a, "t_max"_a, "dt_max"_a, "gyro_max"_a,
+           "prts"_a);
 }

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -292,5 +292,5 @@ NB_MODULE(_openggcm, m)
   nb::class_<boris>(tracing, "boris")
       .def(nb::init<const emfields &>(), "emfields"_a)
       .def("__repr__", &boris::repr)
-      .def("push", &boris::push, "p"_a, "dt"_a);
+      .def("push", &boris::push, "t"_a, "p"_a, "dt"_a, "prts"_a);
 }

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -292,5 +292,6 @@ NB_MODULE(_openggcm, m)
   nb::class_<boris>(tracing, "boris")
       .def(nb::init<const emfields &>(), "emfields"_a)
       .def("__repr__", &boris::repr)
-      .def("push", &boris::push, "t"_a, "p"_a, "dt"_a, "prts"_a);
+      .def("push", &boris::push, "t"_a, "p"_a, "prts"_a, "dt_max"_a,
+           "gyro_max"_a);
 }

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -270,15 +270,12 @@ NB_MODULE(_openggcm, m)
   // ------------------------------------------------------------------
   // particle
   nb::class_<particle>(tracing, "particle")
-      .def(nb::init<double3, double3, double, double>(), "x"_a, "u"_a, "q"_a,
-           "m"_a)
+      .def(nb::init<double3, double3>(), "x"_a, "u"_a)
       .def_prop_ro("v", [](const particle &p) { return p.v(); })
       .def_prop_ro("gamma", [](const particle &p) { return p.gamma(); })
       .def("__repr__", &particle::repr)
       .def_rw("x", &particle::x)
-      .def_rw("u", &particle::u)
-      .def_rw("q", &particle::q)
-      .def_rw("m", &particle::m);
+      .def_rw("u", &particle::u);
 
   // ------------------------------------------------------------------
   // particles
@@ -290,7 +287,8 @@ NB_MODULE(_openggcm, m)
   // ------------------------------------------------------------------
   // boris
   nb::class_<boris>(tracing, "boris")
-      .def(nb::init<const emfields &>(), "emfields"_a)
+      .def(nb::init<const emfields &, double, double>(), "emfields"_a, "q"_a,
+           "m"_a)
       .def("__repr__", &boris::repr)
       .def("push", &boris::push, "prt"_a, "t_max"_a, "dt_max"_a, "gyro_max"_a,
            "prts"_a);

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -3,6 +3,7 @@
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/tuple.h>
+#include <nanobind/stl/vector.h>
 
 #include <openggcm/emfields.hxx>
 #include <openggcm/tracing/boris.hxx>
@@ -278,6 +279,13 @@ NB_MODULE(_openggcm, m)
       .def_rw("u", &particle::u)
       .def_rw("q", &particle::q)
       .def_rw("m", &particle::m);
+
+  // ------------------------------------------------------------------
+  // particles
+  nb::class_<particles>(tracing, "particles")
+      .def(nb::init<>())
+      .def("add_particle", &particles::add_particle, "t"_a, "r"_a, "u"_a)
+      .def("to_tuple", &particles::to_tuple);
 
   // ------------------------------------------------------------------
   // boris

--- a/src/ggcmpy/libopenggcm/tests/test_tracing.cxx
+++ b/src/ggcmpy/libopenggcm/tests/test_tracing.cxx
@@ -7,15 +7,13 @@ using namespace openggcm;
 
 TEST(particle, ctor)
 {
-  tracing::particle p({1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}, -1.0, 1.0);
+  tracing::particle p({1.0, 2.0, 3.0}, {4.0, 5.0, 6.0});
   EXPECT_EQ(p.x, double3({1.0, 2.0, 3.0}));
   EXPECT_EQ(p.u, double3({4.0, 5.0, 6.0}));
-  EXPECT_EQ(p.q, -1.0);
-  EXPECT_EQ(p.m, 1.0);
 }
 
 TEST(particle, gamma)
 {
-  tracing::particle p({1.0, 2.0, 3.0}, {0.0, 0.0, 1.0}, -1.0, 1.0);
+  tracing::particle p({1.0, 2.0, 3.0}, {0.0, 0.0, 1.0});
   EXPECT_EQ(p.gamma(), std::sqrt(2.));
 }

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -303,7 +303,14 @@ class BorisIntegrator_f2py:
 
 class BorisIntegrator_cxx:
     def __init__(self, df, q=constants.e, m=constants.m_e):
-        self._emfields = df
+        from . import emfields
+
+        if isinstance(df, xr.Dataset):
+            self._emfields = emfields.yee_cic_cxx(df)
+        else:
+            assert isinstance(df, (emfields.uniform_cxx, emfields.yee_cic_cxx))
+            self._emfields = df
+
         self._q = q
         self._m = m
 

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -301,6 +301,24 @@ class BorisIntegrator_f2py:
         )
 
 
+class particles_python:
+    def __init__(self) -> None:
+        self._t: list[float] = []
+        self._r: list[np.ndarray] = []
+        self._u: list[np.ndarray] = []
+
+    def add_particle(self, t: float, r: np.ndarray, u: np.ndarray):
+        self._t.append(t)
+        self._r.append(r.copy())
+        self._u.append(u.copy())
+
+    def to_dataframe(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            np.column_stack((self._t, self._r, self._u)),
+            columns=("time", "x", "y", "z", "ux", "uy", "uz"),
+        )
+
+
 class BorisIntegrator_cxx:
     def __init__(self, df, q=constants.e, m=constants.m_e):
         from . import emfields
@@ -321,11 +339,10 @@ class BorisIntegrator_cxx:
         p = _openggcm.tracing.particle(x=x0, u=u0, q=self._q, m=self._m)
         qprime = 0.5 * self._q / self._m
 
-        times, positions, momenta = [], [], []
+        particles = particles_python()
+
         while t < t_max:
-            times.append(t)
-            positions.append(p.x.copy())
-            momenta.append(p.u.copy())
+            particles.add_particle(t, p.x, p.u)
 
             om_c = np.linalg.norm(2.0 * qprime * self._emfields.B(p.x))
             dt = min(dt_max, gyro_max * 2.0 * np.pi / om_c)
@@ -333,10 +350,7 @@ class BorisIntegrator_cxx:
             boris.push(p, dt)
             t += dt
 
-        return pd.DataFrame(
-            np.column_stack((times, positions, momenta)),
-            columns=["time", "x", "y", "z", "ux", "uy", "uz"],
-        )
+        return particles.to_dataframe()
 
 
 BorisIntegrator = BorisIntegrator_python

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -302,6 +302,8 @@ class BorisIntegrator_f2py:
 
 
 class particles_cxx(_openggcm.tracing.particles):  # type: ignore[misc]
+    """Wrapper class for the C++ particles class, providing a convenient interface for particle data management."""
+
     def to_dataframe(self) -> pd.DataFrame:
         t, r, u = self.to_tuple()
         return pd.DataFrame(
@@ -311,9 +313,28 @@ class particles_cxx(_openggcm.tracing.particles):  # type: ignore[misc]
 
 
 class BorisIntegrator_cxx:
-    def __init__(self, df, q=constants.e, m=constants.m_e):
-        from . import emfields
+    """
+    BorisIntegrator_cxx provides an interface for integrating charged particle trajectories
+    using the Boris algorithm, with field interpolation via C++ routines.
 
+    Args:
+        df (xr.Dataset or emfields.interpolator_cxx or emfields.interpolator_yee_cxx):
+            The dataset containing electromagnetic field data, or a pre-initialized field interpolator.
+        q (float, optional):
+            Particle charge in Coulombs. Defaults to the elementary charge (constants.e).
+        m (float, optional):
+            Particle mass in kilograms. Defaults to the electron mass (constants.m_e).
+
+    Attributes:
+        q (float): Particle charge.
+        m (float): Particle mass.
+
+    Methods:
+        integrate(x0, v0, t_max, dt) -> pd.DataFrame:
+            Integrates the particle trajectory using the Boris algorithm.
+    """
+
+    def __init__(self, df, q=constants.e, m=constants.m_e):
         if isinstance(df, xr.Dataset):
             self._emfields = emfields.yee_cic_cxx(df)
         else:

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -328,16 +328,12 @@ class BorisIntegrator_cxx:
 
         t = 0.0
         p = _openggcm.tracing.particle(x=x0, u=u0, q=self._q, m=self._m)
-        qprime = 0.5 * self._q / self._m
 
         particles = particles_cxx()
         particles.add_particle(t, p.x, p.u)
         while t < t_max:
-            om_c = np.linalg.norm(2.0 * qprime * self._emfields.B(p.x))
-            dt = min(dt_max, gyro_max * 2.0 * np.pi / om_c)
-
-            boris.push(t, p, dt, particles)
-            t += dt
+            boris.push(t, p, dt_max, gyro_max, particles)
+            t = particles.to_dataframe().iloc[-1].time
 
         return particles.to_dataframe()
 

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -326,14 +326,10 @@ class BorisIntegrator_cxx:
     def integrate(self, x0, u0, t_max, dt_max=1.0, gyro_max=0.1) -> pd.DataFrame:
         boris = _openggcm.tracing.boris(self._emfields)
 
-        t = 0.0
-        p = _openggcm.tracing.particle(x=x0, u=u0, q=self._q, m=self._m)
+        prt = _openggcm.tracing.particle(x=x0, u=u0, q=self._q, m=self._m)
 
         particles = particles_cxx()
-        particles.add_particle(t, p.x, p.u)
-        while t < t_max:
-            boris.push(t, p, dt_max, gyro_max, particles)
-            t = particles.to_dataframe().iloc[-1].time
+        boris.push(prt, t_max, dt_max, gyro_max, particles)
 
         return particles.to_dataframe()
 

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -301,20 +301,11 @@ class BorisIntegrator_f2py:
         )
 
 
-class particles_python:
-    def __init__(self) -> None:
-        self._t: list[float] = []
-        self._r: list[np.ndarray] = []
-        self._u: list[np.ndarray] = []
-
-    def add_particle(self, t: float, r: np.ndarray, u: np.ndarray):
-        self._t.append(t)
-        self._r.append(r.copy())
-        self._u.append(u.copy())
-
+class particles_cxx(_openggcm.tracing.particles):  # type: ignore[misc]
     def to_dataframe(self) -> pd.DataFrame:
+        t, r, u = self.to_tuple()
         return pd.DataFrame(
-            np.column_stack((self._t, self._r, self._u)),
+            np.column_stack((t, r, u)),
             columns=("time", "x", "y", "z", "ux", "uy", "uz"),
         )
 
@@ -339,8 +330,7 @@ class BorisIntegrator_cxx:
         p = _openggcm.tracing.particle(x=x0, u=u0, q=self._q, m=self._m)
         qprime = 0.5 * self._q / self._m
 
-        particles = particles_python()
-
+        particles = particles_cxx()
         while t < t_max:
             particles.add_particle(t, p.x, p.u)
 

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -324,11 +324,11 @@ class BorisIntegrator_cxx:
         self._m = m
 
     def integrate(self, x0, u0, t_max, dt_max=1.0, gyro_max=0.1) -> pd.DataFrame:
-        boris = _openggcm.tracing.boris(self._emfields)
+        boris = _openggcm.tracing.boris(self._emfields, self._q, self._m)
 
-        prt = _openggcm.tracing.particle(x=x0, u=u0, q=self._q, m=self._m)
-
+        prt = _openggcm.tracing.particle(x=x0, u=u0)
         particles = particles_cxx()
+
         boris.push(prt, t_max, dt_max, gyro_max, particles)
 
         return particles.to_dataframe()

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -14,7 +14,10 @@ import pandas as pd
 import xarray as xr
 from scipy import constants  # type: ignore[import-untyped]
 
-from ggcmpy import _jrrle  # type: ignore[attr-defined]
+from ggcmpy import (  # type: ignore[attr-defined]
+    _jrrle,
+    _openggcm,
+)
 
 from . import emfields
 
@@ -295,6 +298,37 @@ class BorisIntegrator_f2py:
         )
         return pd.DataFrame(
             data.T[:n_out], columns=["time", "x", "y", "z", "ux", "uy", "uz"]
+        )
+
+
+class BorisIntegrator_cxx:
+    def __init__(self, df, q=constants.e, m=constants.m_e):
+        self._emfields = df
+        self._q = q
+        self._m = m
+
+    def integrate(self, x0, u0, t_max, dt_max=1.0, gyro_max=0.1) -> pd.DataFrame:
+        boris = _openggcm.tracing.boris(self._emfields)
+
+        t = 0.0
+        p = _openggcm.tracing.particle(x=x0, u=u0, q=self._q, m=self._m)
+        qprime = 0.5 * self._q / self._m
+
+        times, positions, momenta = [], [], []
+        while t < t_max:
+            times.append(t)
+            positions.append(p.x.copy())
+            momenta.append(p.u.copy())
+
+            om_c = np.linalg.norm(2.0 * qprime * self._emfields.B(p.x))
+            dt = min(dt_max, gyro_max * 2.0 * np.pi / om_c)
+
+            boris.push(p, dt)
+            t += dt
+
+        return pd.DataFrame(
+            np.column_stack((times, positions, momenta)),
+            columns=["time", "x", "y", "z", "ux", "uy", "uz"],
         )
 
 

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -331,14 +331,14 @@ class BorisIntegrator_cxx:
         qprime = 0.5 * self._q / self._m
 
         particles = particles_cxx()
+        particles.add_particle(t, p.x, p.u)
         while t < t_max:
-            particles.add_particle(t, p.x, p.u)
-
             om_c = np.linalg.norm(2.0 * qprime * self._emfields.B(p.x))
             dt = min(dt_max, gyro_max * 2.0 * np.pi / om_c)
 
             boris.push(p, dt)
             t += dt
+            particles.add_particle(t, p.x, p.u)
 
         return particles.to_dataframe()
 

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -336,9 +336,8 @@ class BorisIntegrator_cxx:
             om_c = np.linalg.norm(2.0 * qprime * self._emfields.B(p.x))
             dt = min(dt_max, gyro_max * 2.0 * np.pi / om_c)
 
-            boris.push(p, dt)
+            boris.push(t, p, dt, particles)
             t += dt
-            particles.add_particle(t, p.x, p.u)
 
         return particles.to_dataframe()
 

--- a/src/ggcmpy/tracing/emfields.py
+++ b/src/ggcmpy/tracing/emfields.py
@@ -148,6 +148,12 @@ class yee_cic_cxx(_openggcm.emfields_yee_cic):  # type: ignore[misc]
             ds["z_nc"].to_numpy(),
         )
 
+    def B(self, r: np.ndarray) -> np.ndarray:
+        return np.asarray(super().B(r))
+
+    def E(self, r: np.ndarray) -> np.ndarray:
+        return np.asarray(super().E(r))
+
 
 class yee_tsc_cxx(_openggcm.emfields_yee_tsc):  # type: ignore[misc]
     """

--- a/src/ggcmpy/tracing/emfields.py
+++ b/src/ggcmpy/tracing/emfields.py
@@ -37,6 +37,16 @@ class uniform_python:
 
 
 class uniform_cxx(_openggcm.emfields_uniform):  # type: ignore[misc]
+    """
+    A class representing a uniform electromagnetic field using C++ implementation.
+
+    Methods:
+        B(x: np.ndarray) -> np.ndarray:
+            Returns the uniform magnetic field vector, independent of position x.
+        E(x: np.ndarray) -> np.ndarray:
+            Returns the uniform electric field vector, independent of position x.
+    """
+
     def B(self, r: ArrayLike) -> np.ndarray:
         return np.asarray(super().B(r))
 

--- a/src/ggcmpy/tracing/emfields.py
+++ b/src/ggcmpy/tracing/emfields.py
@@ -36,7 +36,12 @@ class uniform_python:
         return self.E_0
 
 
-uniform_cxx = _openggcm.emfields_uniform
+class uniform_cxx(_openggcm.emfields_uniform):  # type: ignore[misc]
+    def B(self, r: ArrayLike) -> np.ndarray:
+        return np.asarray(super().B(r))
+
+    def E(self, r: ArrayLike) -> np.ndarray:
+        return np.asarray(super().E(r))
 
 
 class dipole_python:

--- a/tests/test_particle_tracing.py
+++ b/tests/test_particle_tracing.py
@@ -65,7 +65,7 @@ def test_BorisIntegrator_uniform():
     m = constants.m_e  # [kg]
     B_0 = 1e-8  # [T]
     v_0 = 0.5 * constants.c
-    emfields = ggcmpy.tracing.emfields.uniform(B_0=np.array([0.0, 0.0, B_0]))
+    emfields = ggcmpy.tracing.emfields.uniform_cxx(B_0=np.array([0.0, 0.0, B_0]))
     x0 = np.array([0.0, 0.0, 0.0])  # [m]
     v0 = np.array([0.0, v_0, 0.0])  # [m/s]
     gamma = 1.0 / np.sqrt(1 - (np.linalg.norm(v0) / constants.c) ** 2)

--- a/tests/test_particle_tracing.py
+++ b/tests/test_particle_tracing.py
@@ -86,7 +86,8 @@ def test_BorisIntegrator_uniform(Integrator):
     boris = Integrator(emfields, q, m)
     df = boris.integrate(x0, u0, t_max, dt)
 
-    assert len(df) == steps + 1
+    assert len(df) >= steps
+    assert len(df) <= steps + 2
 
     assert np.allclose(df.ux, np.sin(om_ce * df.time) * u0[1], atol=1e-2 * u0[1])
     assert np.allclose(df.uy, np.cos(om_ce * df.time) * u0[1], atol=1e-2 * u0[1])
@@ -125,7 +126,8 @@ def test_BorisIntegrator(Integrator):
     boris = Integrator(field_cc, q, m)
     df = boris.integrate(x0, u0, t_max, dt)
 
-    assert len(df) == steps + 1
+    assert len(df) >= steps
+    assert len(df) <= steps + 2
 
     assert np.allclose(df.ux, np.sin(om_ce * df.time) * u0[1], atol=1e-2 * u0[1])
     assert np.allclose(df.uy, np.cos(om_ce * df.time) * u0[1], atol=1e-2 * u0[1])

--- a/tests/test_particle_tracing.py
+++ b/tests/test_particle_tracing.py
@@ -59,7 +59,14 @@ def test_interpolate():
     )
 
 
-def test_BorisIntegrator_uniform():
+@pytest.mark.parametrize(
+    "Integrator",
+    [
+        ggcmpy.tracing.BorisIntegrator_python,
+        ggcmpy.tracing.BorisIntegrator_cxx,
+    ],
+)
+def test_BorisIntegrator_uniform(Integrator):
     """particle gyrating in a uniform magnetic field"""
     q = constants.e  # [C]
     m = constants.m_e  # [kg]
@@ -76,7 +83,7 @@ def test_BorisIntegrator_uniform():
     steps = 100
     dt = t_max / steps  # [s]
 
-    boris = ggcmpy.tracing.BorisIntegrator_python(emfields, q, m)
+    boris = Integrator(emfields, q, m)
     df = boris.integrate(x0, u0, t_max, dt)
 
     assert len(df) == steps + 1

--- a/tests/test_particle_tracing.py
+++ b/tests/test_particle_tracing.py
@@ -138,7 +138,11 @@ def test_BorisIntegrator(Integrator):
 
 @pytest.mark.parametrize(
     "Integrator",
-    [ggcmpy.tracing.BorisIntegrator_python, ggcmpy.tracing.BorisIntegrator_f2py],
+    [
+        ggcmpy.tracing.BorisIntegrator_python,
+        ggcmpy.tracing.BorisIntegrator_f2py,
+        ggcmpy.tracing.BorisIntegrator_cxx,
+    ],
 )
 def test_BorisIntegratorYee(Integrator):
     """particle gyrating in a uniform magnetic field"""

--- a/tests/test_particles.py
+++ b/tests/test_particles.py
@@ -5,13 +5,9 @@ from ggcmpy._openggcm.tracing import particle  # type: ignore[import-not-found]
 
 
 def test_particle_ctor():
-    prt = particle(
-        x=np.array([0.0, 0.0, 0.0]), u=np.array([1.0, 0.0, 0.0]), q=-1.0, m=1.0
-    )
+    prt = particle(x=np.array([0.0, 0.0, 0.0]), u=np.array([1.0, 0.0, 0.0]))
     assert np.allclose(prt.x, np.array([0.0, 0.0, 0.0]))
     assert np.allclose(prt.u, np.array([1.0, 0.0, 0.0]))
     prt.x = [1.0, 2.0, 3.0]
     assert np.allclose(prt.x, np.array([1.0, 2.0, 3.0]))
-    assert np.isclose(prt.q, -1.0)
-    assert np.isclose(prt.m, 1.0)
     assert np.isclose(prt.gamma, np.sqrt(2.0))


### PR DESCRIPTION
This pull request introduces a C++ implementation of the Boris particle pusher for relativistic particle tracing, exposes it to Python via nanobind, and integrates it into the Python API. It also refactors the `particle` class to remove charge and mass fields (now set at the integrator level), introduces a new `particles` container class, and enhances the test suite to cover the new C++ implementation. Several utility improvements and interface adjustments are included for better usability and consistency.

The most important changes are:

### C++ Boris Integrator and Python Bindings

* Adds a new C++ class `boris` implementing the relativistic Boris particle pusher in `boris.hxx`, with methods for advancing particle position and velocity, and exposes it to Python via nanobind. [[1]](diffhunk://#diff-ed0e20ecbda8377bc8a737d91e448f59ece80f1fdd56260bcc9d4edca024678bR1-R94) [[2]](diffhunk://#diff-2a90038e562d5ce605014ad8a808f543af671a9cb4bac85833c19880a11ba5b0L270-R294)
* Introduces a `particles` container class in C++ and Python for storing particle trajectories, with a method to convert to a tuple for easy DataFrame construction. [[1]](diffhunk://#diff-d4aa7aca19f5703bcb69876fe8a67c8645728963c89f2408526cc31b481213a1L28-R54) [[2]](diffhunk://#diff-2a90038e562d5ce605014ad8a808f543af671a9cb4bac85833c19880a11ba5b0L270-R294) [[3]](diffhunk://#diff-9f383faa9413660d10ceea27743dbc7c4836918d427d1b39a762aa4cfec28ee6R304-R336)

### Refactoring and Interface Changes

* Refactors the `particle` class to remove the `q` (charge) and `m` (mass) fields, making it a simple container for position and velocity; charge and mass are now provided to the integrator. Updates all relevant constructors and tests accordingly. [[1]](diffhunk://#diff-d4aa7aca19f5703bcb69876fe8a67c8645728963c89f2408526cc31b481213a1L15-R15) [[2]](diffhunk://#diff-2a90038e562d5ce605014ad8a808f543af671a9cb4bac85833c19880a11ba5b0L270-R294) [[3]](diffhunk://#diff-efbb997ee3a86a9c3d6c18e04c89315fc808178071a6f519bc4110dfb5435f74L10-R17) [[4]](diffhunk://#diff-fbcd89f59e2b3cfdb6cfe102b1d8db9ea0009691e8031e2a23ead02c7b88588eL8-L16)

### Python API Extensions

* Adds `BorisIntegrator_cxx` Python class, wrapping the new C++ integrator, and provides a `to_dataframe` method for easy analysis with pandas.
* Updates the Python emfields wrappers (`uniform_cxx`, etc.) to ensure returned arrays are properly converted to numpy arrays. (F07fd677L36R7, [src/ggcmpy/tracing/emfields.pyR151-R156](diffhunk://#diff-04298adb77ac6413c9c95289f4168137c67b81aeae08c9bda304e162fcbd3513R151-R156))

### Usability Improvements

* Updates the nanobind bindings to allow default arguments for `emfields_uniform` and exposes STL vectors for easier data handling. [[1]](diffhunk://#diff-2a90038e562d5ce605014ad8a808f543af671a9cb4bac85833c19880a11ba5b0L239-R242) [[2]](diffhunk://#diff-2a90038e562d5ce605014ad8a808f543af671a9cb4bac85833c19880a11ba5b0R6-R9)
* Adds a utility function `norm2` for squared norm calculations in C++.

### Testing

* Extends the test suite to parameterize tests over the Python, F2PY, and new C++ Boris integrators, ensuring consistent results across implementations. [[1]](diffhunk://#diff-a2459590a678e8c3cc4d0e4651ed2c081e05fc5eeb085e1efa76106c89169db3L62-R75) [[2]](diffhunk://#diff-a2459590a678e8c3cc4d0e4651ed2c081e05fc5eeb085e1efa76106c89169db3L79-R90) [[3]](diffhunk://#diff-a2459590a678e8c3cc4d0e4651ed2c081e05fc5eeb085e1efa76106c89169db3L121-R130) [[4]](diffhunk://#diff-a2459590a678e8c3cc4d0e4651ed2c081e05fc5eeb085e1efa76106c89169db3L134-R147)

These changes collectively provide a high-performance, C++-backed Boris integrator for particle tracing, improve the maintainability of the codebase, and ensure robust testing and usability from Python.