### PR TITLE
Refactor particle handling and initialization in C++

### DIFF
--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
@@ -63,15 +63,20 @@ public:
     u = up + dq * E / constants::c;
   }
 
-  void push(double3 x, double3 u, double t_max, double dt_max, double gyro_max,
+  void push(particles &prts, double t_max, double dt_max, double gyro_max,
             particles &prts_snapshots) const
   {
     double qprime = 0.5 * q_ / m_;
+
+    auto [ts, xs, us] = prts.to_tuple();
+    double t = ts.front();
+    double3 x = xs.front();
+    double3 u = us.front();
+
     double3 B = emfields_.get().B(x);
     double om_c = 2.0 * std::abs(qprime) * norm(B);
     double dt = std::min(dt_max, gyro_max * 2.0 * constants::pi / om_c);
 
-    double t = 0.;
     prts_snapshots.add_particle(t, x, u);
 
     while (t < t_max)

--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
@@ -77,8 +77,6 @@ public:
     double om_c = 2.0 * std::abs(qprime) * norm(B);
     double dt = std::min(dt_max, gyro_max * 2.0 * constants::pi / om_c);
 
-    prts_snapshots.add_particle(t, x, u);
-
     while (t < t_max)
     {
       push_x(x, u, .5 * dt);

--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
@@ -63,8 +63,7 @@ public:
     u = up + dq * E / constants::c;
   }
 
-  void push(particles &prts, double t_max, double dt_max, double gyro_max,
-            particles &prts_snapshots) const
+  void push(particles &prts, double t_max, double dt_max, double gyro_max) const
   {
     double qprime = 0.5 * q_ / m_;
 
@@ -82,7 +81,6 @@ public:
       push_u(x, u, dt);
       push_x(x, u, .5 * dt);
       t += dt;
-      prts_snapshots.add_particle(t, x, u);
     }
   }
 

--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
@@ -64,7 +64,7 @@ public:
   }
 
   void push(double3 x, double3 u, double t_max, double dt_max, double gyro_max,
-            particles &prts) const
+            particles &prts_snapshots) const
   {
     double qprime = 0.5 * q_ / m_;
     double3 B = emfields_.get().B(x);
@@ -72,7 +72,7 @@ public:
     double dt = std::min(dt_max, gyro_max * 2.0 * constants::pi / om_c);
 
     double t = 0.;
-    prts.add_particle(t, x, u);
+    prts_snapshots.add_particle(t, x, u);
 
     while (t < t_max)
     {
@@ -80,7 +80,7 @@ public:
       push_u(x, u, dt);
       push_x(x, u, .5 * dt);
       t += dt;
-      prts.add_particle(t, x, u);
+      prts_snapshots.add_particle(t, x, u);
     }
   }
 

--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
@@ -63,24 +63,24 @@ public:
     u = up + dq * E / constants::c;
   }
 
-  void push(particle &prt, double t_max, double dt_max, double gyro_max,
+  void push(double3 x, double3 u, double t_max, double dt_max, double gyro_max,
             particles &prts) const
   {
     double qprime = 0.5 * q_ / m_;
-    double3 B = emfields_.get().B(prt.x);
+    double3 B = emfields_.get().B(x);
     double om_c = 2.0 * std::abs(qprime) * norm(B);
     double dt = std::min(dt_max, gyro_max * 2.0 * constants::pi / om_c);
 
     double t = 0.;
-    prts.add_particle(t, prt.x, prt.u);
+    prts.add_particle(t, x, u);
 
     while (t < t_max)
     {
-      push_x(prt.x, prt.u, .5 * dt);
-      push_u(prt.x, prt.u, dt);
-      push_x(prt.x, prt.u, .5 * dt);
+      push_x(x, u, .5 * dt);
+      push_u(x, u, dt);
+      push_x(x, u, .5 * dt);
       t += dt;
-      prts.add_particle(t, prt.x, prt.u);
+      prts.add_particle(t, x, u);
     }
   }
 

--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
@@ -68,10 +68,9 @@ public:
   {
     double qprime = 0.5 * q_ / m_;
 
-    auto [ts, xs, us] = prts.to_tuple();
-    double t = ts.front();
-    double3 x = xs.front();
-    double3 u = us.front();
+    double &t = prts.t(0);
+    double3 &x = prts.r(0);
+    double3 &u = prts.u(0);
 
     double3 B = emfields_.get().B(x);
     double om_c = 2.0 * std::abs(qprime) * norm(B);

--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/particle.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/particle.hxx
@@ -19,6 +19,13 @@ public:
     u_.push_back(u);
   }
 
+  double t(std::size_t i) const { return t_[i]; }
+  double3 r(std::size_t i) const { return r_[i]; }
+  double3 u(std::size_t i) const { return u_[i]; }
+  double &t(std::size_t i) { return t_[i]; }
+  double3 &r(std::size_t i) { return r_[i]; }
+  double3 &u(std::size_t i) { return u_[i]; }
+
   std::tuple<std::vector<double>, std::vector<double3>, std::vector<double3>>
   to_tuple() const
   {

--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/particle.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/particle.hxx
@@ -9,29 +9,6 @@ namespace openggcm
 namespace tracing
 {
 
-class particle
-{
-public:
-  particle(double3 x, double3 u) : x(x), u(u) {}
-
-  double3 v() const { return (constants::c / gamma()) * u; }
-
-  double gamma() const
-  {
-    return std::sqrt(1.0 + sqr(u[0]) + sqr(u[1]) + sqr(u[2]));
-  }
-
-  std::string repr() const
-  {
-    return "particle(x=[" + std::to_string(x[0]) + ", " + std::to_string(x[1]) +
-           ", " + std::to_string(x[2]) + "], u=[" + std::to_string(u[0]) +
-           ", " + std::to_string(u[1]) + ", " + std::to_string(u[2]) + "])";
-  }
-
-  double3 x;
-  double3 u;
-};
-
 class particles
 {
 public:

--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/particle.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/particle.hxx
@@ -12,6 +12,24 @@ namespace tracing
 class particles
 {
 public:
+  particles() = default;
+  template <typename E>
+  particles(const xt::xexpression<E> &t, const xt::xexpression<E> &r,
+            const xt::xexpression<E> &u)
+  {
+    t_.reserve(t.derived_cast().shape(0));
+    r_.reserve(r.derived_cast().shape(0));
+    u_.reserve(u.derived_cast().shape(0));
+    for (std::size_t i = 0; i < t.derived_cast().shape(0); ++i)
+    {
+      add_particle(t.derived_cast()(i),
+                   double3{r.derived_cast()(i, 0), r.derived_cast()(i, 1),
+                           r.derived_cast()(i, 2)},
+                   double3{u.derived_cast()(i, 0), u.derived_cast()(i, 1),
+                           u.derived_cast()(i, 2)});
+    }
+  }
+
   void add_particle(double t, double3 r, double3 u)
   {
     t_.push_back(t);

--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/particle.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/particle.hxx
@@ -26,6 +26,10 @@ public:
   double3 &r(std::size_t i) { return r_[i]; }
   double3 &u(std::size_t i) { return u_[i]; }
 
+  std::vector<double> &t() { return t_; }
+  std::vector<double3> &r() { return r_; }
+  std::vector<double3> &u() { return u_; }
+
   std::tuple<std::vector<double>, std::vector<double3>, std::vector<double3>>
   to_tuple() const
   {

--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/particle.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/particle.hxx
@@ -22,19 +22,12 @@ public:
     u_.reserve(u.derived_cast().shape(0));
     for (std::size_t i = 0; i < t.derived_cast().shape(0); ++i)
     {
-      add_particle(t.derived_cast()(i),
-                   double3{r.derived_cast()(i, 0), r.derived_cast()(i, 1),
-                           r.derived_cast()(i, 2)},
-                   double3{u.derived_cast()(i, 0), u.derived_cast()(i, 1),
+      t_.push_back(t.derived_cast()(i));
+      r_.push_back(double3{r.derived_cast()(i, 0), r.derived_cast()(i, 1),
+                           r.derived_cast()(i, 2)});
+      u_.push_back(double3{u.derived_cast()(i, 0), u.derived_cast()(i, 1),
                            u.derived_cast()(i, 2)});
     }
-  }
-
-  void add_particle(double t, double3 r, double3 u)
-  {
-    t_.push_back(t);
-    r_.push_back(r);
-    u_.push_back(u);
   }
 
   double t(std::size_t i) const { return t_[i]; }

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -280,6 +280,6 @@ NB_MODULE(_openggcm, m)
       .def(nb::init<const emfields &, double, double>(), "emfields"_a, "q"_a,
            "m"_a)
       .def("__repr__", &boris::repr)
-      .def("push", &boris::push, "x"_a, "u"_a, "t_max"_a, "dt_max"_a,
-           "gyro_max"_a, "prts_snapshots"_a);
+      .def("push", &boris::push, "prts"_a, "t_max"_a, "dt_max"_a, "gyro_max"_a,
+           "prts_snapshots"_a);
 }

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -283,6 +283,5 @@ NB_MODULE(_openggcm, m)
       .def(nb::init<const emfields &, double, double>(), "emfields"_a, "q"_a,
            "m"_a)
       .def("__repr__", &boris::repr)
-      .def("push", &boris::push, "prts"_a, "t_max"_a, "dt_max"_a, "gyro_max"_a,
-           "prts_snapshots"_a);
+      .def("push", &boris::push, "prts"_a, "t_max"_a, "dt_max"_a, "gyro_max"_a);
 }

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -290,6 +290,6 @@ NB_MODULE(_openggcm, m)
       .def(nb::init<const emfields &, double, double>(), "emfields"_a, "q"_a,
            "m"_a)
       .def("__repr__", &boris::repr)
-      .def("push", &boris::push, "prt"_a, "t_max"_a, "dt_max"_a, "gyro_max"_a,
-           "prts"_a);
+      .def("push", &boris::push, "x"_a, "u"_a, "t_max"_a, "dt_max"_a,
+           "gyro_max"_a, "prts"_a);
 }

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -279,7 +279,6 @@ NB_MODULE(_openggcm, m)
                                       xt_adapt_ndarray(u));
                }),
            "t"_a, "r"_a, "u"_a)
-      .def("add_particle", &particles::add_particle, "t"_a, "r"_a, "u"_a)
       .def_prop_ro("t", [](particles &p) { return p.t(); })
       .def_prop_ro("r", [](particles &p) { return p.r(); })
       .def_prop_ro("u", [](particles &p) { return p.u(); })

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -270,7 +270,15 @@ NB_MODULE(_openggcm, m)
   // ------------------------------------------------------------------
   // particles
   nb::class_<particles>(tracing, "particles")
-      .def(nb::init<>())
+      .def(nb::new_(
+               [](nb_ndarray_type<const double> t,
+                  nb_ndarray_type<const double> r,
+                  nb_ndarray_type<const double> u)
+               {
+                 return new particles(xt_adapt_ndarray(t), xt_adapt_ndarray(r),
+                                      xt_adapt_ndarray(u));
+               }),
+           "t"_a, "r"_a, "u"_a)
       .def("add_particle", &particles::add_particle, "t"_a, "r"_a, "u"_a)
       .def_prop_ro("t", [](particles &p) { return p.t(); })
       .def_prop_ro("r", [](particles &p) { return p.r(); })

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -281,5 +281,5 @@ NB_MODULE(_openggcm, m)
            "m"_a)
       .def("__repr__", &boris::repr)
       .def("push", &boris::push, "x"_a, "u"_a, "t_max"_a, "dt_max"_a,
-           "gyro_max"_a, "prts"_a);
+           "gyro_max"_a, "prts_snapshots"_a);
 }

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -272,6 +272,9 @@ NB_MODULE(_openggcm, m)
   nb::class_<particles>(tracing, "particles")
       .def(nb::init<>())
       .def("add_particle", &particles::add_particle, "t"_a, "r"_a, "u"_a)
+      .def_prop_ro("t", [](particles &p) { return p.t(); })
+      .def_prop_ro("r", [](particles &p) { return p.r(); })
+      .def_prop_ro("u", [](particles &p) { return p.u(); })
       .def("to_tuple", &particles::to_tuple);
 
   // ------------------------------------------------------------------

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -268,16 +268,6 @@ NB_MODULE(_openggcm, m)
   nb::module_ tracing = m.def_submodule("tracing", "tracing submodule");
 
   // ------------------------------------------------------------------
-  // particle
-  nb::class_<particle>(tracing, "particle")
-      .def(nb::init<double3, double3>(), "x"_a, "u"_a)
-      .def_prop_ro("v", [](const particle &p) { return p.v(); })
-      .def_prop_ro("gamma", [](const particle &p) { return p.gamma(); })
-      .def("__repr__", &particle::repr)
-      .def_rw("x", &particle::x)
-      .def_rw("u", &particle::u);
-
-  // ------------------------------------------------------------------
   // particles
   nb::class_<particles>(tracing, "particles")
       .def(nb::init<>())

--- a/src/ggcmpy/libopenggcm/tests/test_tracing.cxx
+++ b/src/ggcmpy/libopenggcm/tests/test_tracing.cxx
@@ -4,16 +4,3 @@
 #include <openggcm/tracing/particle.hxx>
 
 using namespace openggcm;
-
-TEST(particle, ctor)
-{
-  tracing::particle p({1.0, 2.0, 3.0}, {4.0, 5.0, 6.0});
-  EXPECT_EQ(p.x, double3({1.0, 2.0, 3.0}));
-  EXPECT_EQ(p.u, double3({4.0, 5.0, 6.0}));
-}
-
-TEST(particle, gamma)
-{
-  tracing::particle p({1.0, 2.0, 3.0}, {0.0, 0.0, 1.0});
-  EXPECT_EQ(p.gamma(), std::sqrt(2.));
-}

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -308,7 +308,7 @@ class particles_cxx(_openggcm.tracing.particles):  # type: ignore[misc]
         t = df["time"].to_numpy()
         r = df[["x", "y", "z"]].to_numpy()
         u = df[["ux", "uy", "uz"]].to_numpy()
-        return super().__new__(cls, t, r, u)  # type: ignore[no-any-return]
+        return super().__new__(cls, t, r, u)  # type: ignore[no-any-return] # pylint: disable=E1121
 
     def __init__(self, df: pd.DataFrame) -> None:
         pass
@@ -322,6 +322,8 @@ class particles_cxx(_openggcm.tracing.particles):  # type: ignore[misc]
 
 
 class boris_cxx(_openggcm.tracing.boris):  # type: ignore[misc]
+    """Wrapper class for the C++ boris class, providing a convenient interface for particle integration."""
+
     def push(
         self, prts_df: pd.DataFrame, t_max: float, dt_max: float, gyro_max: float
     ) -> pd.DataFrame:

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -349,14 +349,13 @@ class BorisIntegrator_cxx:
 
         prts = particles_cxx()
         prts.add_particle(0.0, x0, u0)
-        prts_snapshots = particles_cxx()
-        prts_snapshots.add_particle(0.0, x0, u0)
+        snapshots = [prts.to_dataframe()]
 
         while prts.t[0] < t_max:
             boris.push(prts, prts.t[0] + 1e-7, dt_max, gyro_max)
-            prts_snapshots.add_particle(prts.t[0], prts.r[0], prts.u[0])
+            snapshots.append(prts.to_dataframe())
 
-        return prts_snapshots.to_dataframe()
+        return pd.concat(snapshots, ignore_index=True)
 
 
 BorisIntegrator = BorisIntegrator_python

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -347,10 +347,9 @@ class BorisIntegrator_cxx:
     def integrate(self, x0, u0, t_max, dt_max=1.0, gyro_max=0.1) -> pd.DataFrame:
         boris = _openggcm.tracing.boris(self._emfields, self._q, self._m)
 
-        prt = _openggcm.tracing.particle(x=x0, u=u0)
         particles = particles_cxx()
 
-        boris.push(prt, t_max, dt_max, gyro_max, particles)
+        boris.push(x0, u0, t_max, dt_max, gyro_max, particles)
 
         return particles.to_dataframe()
 

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -347,9 +347,11 @@ class BorisIntegrator_cxx:
     def integrate(self, x0, u0, t_max, dt_max=1.0, gyro_max=0.1) -> pd.DataFrame:
         boris = _openggcm.tracing.boris(self._emfields, self._q, self._m)
 
+        prts = particles_cxx()
+        prts.add_particle(0.0, x0, u0)
         prts_snapshots = particles_cxx()
 
-        boris.push(x0, u0, t_max, dt_max, gyro_max, prts_snapshots)
+        boris.push(prts, t_max, dt_max, gyro_max, prts_snapshots)
 
         return prts_snapshots.to_dataframe()
 

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -321,6 +321,16 @@ class particles_cxx(_openggcm.tracing.particles):  # type: ignore[misc]
         )
 
 
+class boris_cxx(_openggcm.tracing.boris):  # type: ignore[misc]
+    def __init__(self, emfields, q=constants.e, m=constants.m_e) -> None:
+        super().__init__(emfields, q, m)
+
+    def push(
+        self, prts: particles_cxx, t_max: float, dt_max: float, gyro_max: float
+    ) -> None:
+        super().push(prts, t_max, dt_max, gyro_max)
+
+
 class BorisIntegrator_cxx:
     """
     BorisIntegrator_cxx provides an interface for integrating charged particle trajectories
@@ -354,7 +364,7 @@ class BorisIntegrator_cxx:
         self._m = m
 
     def integrate(self, x0, u0, t_max, dt_max=1.0, gyro_max=0.1) -> pd.DataFrame:
-        boris = _openggcm.tracing.boris(self._emfields, self._q, self._m)
+        boris = boris_cxx(self._emfields, self._q, self._m)
 
         prts_df = pd.DataFrame(
             np.array([[0.0, *x0, *u0]]),

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -304,6 +304,15 @@ class BorisIntegrator_f2py:
 class particles_cxx(_openggcm.tracing.particles):  # type: ignore[misc]
     """Wrapper class for the C++ particles class, providing a convenient interface for particle data management."""
 
+    def __init__(self, df: pd.DataFrame) -> None:
+        super().__init__()
+        for _, row in df.iterrows():
+            self.add_particle(
+                row["time"],
+                row[["x", "y", "z"]].to_numpy(),
+                row[["ux", "uy", "uz"]].to_numpy(),
+            )
+
     def to_dataframe(self) -> pd.DataFrame:
         t, r, u = self.to_tuple()
         return pd.DataFrame(
@@ -347,8 +356,11 @@ class BorisIntegrator_cxx:
     def integrate(self, x0, u0, t_max, dt_max=1.0, gyro_max=0.1) -> pd.DataFrame:
         boris = _openggcm.tracing.boris(self._emfields, self._q, self._m)
 
-        prts = particles_cxx()
-        prts.add_particle(0.0, x0, u0)
+        prts_df = pd.DataFrame(
+            np.array([[0.0, *x0, *u0]]),
+            columns=["time", "x", "y", "z", "ux", "uy", "uz"],
+        )
+        prts = particles_cxx(prts_df)
         snapshots = [prts.to_dataframe()]
 
         while prts.t[0] < t_max:

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -327,8 +327,9 @@ class boris_cxx(_openggcm.tracing.boris):  # type: ignore[misc]
 
     def push(
         self, prts: particles_cxx, t_max: float, dt_max: float, gyro_max: float
-    ) -> None:
+    ) -> pd.DataFrame:
         super().push(prts, t_max, dt_max, gyro_max)
+        return prts.to_dataframe()
 
 
 class BorisIntegrator_cxx:
@@ -374,8 +375,8 @@ class BorisIntegrator_cxx:
         snapshots = [prts.to_dataframe()]
 
         while prts.t[0] < t_max:
-            boris.push(prts, prts.t[0] + 1e-7, dt_max, gyro_max)
-            snapshots.append(prts.to_dataframe())
+            prts_df = boris.push(prts, prts.t[0] + 1e-7, dt_max, gyro_max)
+            snapshots.append(prts_df)
 
         return pd.concat(snapshots, ignore_index=True)
 

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -304,14 +304,14 @@ class BorisIntegrator_f2py:
 class particles_cxx(_openggcm.tracing.particles):  # type: ignore[misc]
     """Wrapper class for the C++ particles class, providing a convenient interface for particle data management."""
 
+    def __new__(cls, df: pd.DataFrame) -> particles_cxx:
+        t = df["time"].to_numpy()
+        r = df[["x", "y", "z"]].to_numpy()
+        u = df[["ux", "uy", "uz"]].to_numpy()
+        return super().__new__(cls, t, r, u)  # type: ignore[no-any-return]
+
     def __init__(self, df: pd.DataFrame) -> None:
-        super().__init__()
-        for _, row in df.iterrows():
-            self.add_particle(
-                row["time"],
-                row[["x", "y", "z"]].to_numpy(),
-                row[["ux", "uy", "uz"]].to_numpy(),
-            )
+        pass
 
     def to_dataframe(self) -> pd.DataFrame:
         t, r, u = self.to_tuple()

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -350,6 +350,7 @@ class BorisIntegrator_cxx:
         prts = particles_cxx()
         prts.add_particle(0.0, x0, u0)
         prts_snapshots = particles_cxx()
+        prts_snapshots.add_particle(0.0, x0, u0)
 
         boris.push(prts, t_max, dt_max, gyro_max, prts_snapshots)
 

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -352,7 +352,9 @@ class BorisIntegrator_cxx:
         prts_snapshots = particles_cxx()
         prts_snapshots.add_particle(0.0, x0, u0)
 
-        boris.push(prts, t_max, dt_max, gyro_max, prts_snapshots)
+        while prts.t[0] < t_max:
+            boris.push(prts, prts.t[0] + 1e-7, dt_max, gyro_max)
+            prts_snapshots.add_particle(prts.t[0], prts.r[0], prts.u[0])
 
         return prts_snapshots.to_dataframe()
 

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -322,9 +322,6 @@ class particles_cxx(_openggcm.tracing.particles):  # type: ignore[misc]
 
 
 class boris_cxx(_openggcm.tracing.boris):  # type: ignore[misc]
-    def __init__(self, emfields, q=constants.e, m=constants.m_e) -> None:
-        super().__init__(emfields, q, m)
-
     def push(
         self, prts_df: pd.DataFrame, t_max: float, dt_max: float, gyro_max: float
     ) -> pd.DataFrame:

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -326,8 +326,9 @@ class boris_cxx(_openggcm.tracing.boris):  # type: ignore[misc]
         super().__init__(emfields, q, m)
 
     def push(
-        self, prts: particles_cxx, t_max: float, dt_max: float, gyro_max: float
+        self, prts_df: pd.DataFrame, t_max: float, dt_max: float, gyro_max: float
     ) -> pd.DataFrame:
+        prts = particles_cxx(prts_df)
         super().push(prts, t_max, dt_max, gyro_max)
         return prts.to_dataframe()
 
@@ -371,11 +372,11 @@ class BorisIntegrator_cxx:
             np.array([[0.0, *x0, *u0]]),
             columns=["time", "x", "y", "z", "ux", "uy", "uz"],
         )
-        prts = particles_cxx(prts_df)
-        snapshots = [prts.to_dataframe()]
+        snapshots = [prts_df]
 
-        while prts.t[0] < t_max:
-            prts_df = boris.push(prts, prts.t[0] + 1e-7, dt_max, gyro_max)
+        while prts_df.iloc[0].time < t_max:
+            # hack to make the boris push do just one time step
+            prts_df = boris.push(prts_df, prts_df.iloc[0].time + 1e-7, dt_max, gyro_max)
             snapshots.append(prts_df)
 
         return pd.concat(snapshots, ignore_index=True)

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -347,11 +347,11 @@ class BorisIntegrator_cxx:
     def integrate(self, x0, u0, t_max, dt_max=1.0, gyro_max=0.1) -> pd.DataFrame:
         boris = _openggcm.tracing.boris(self._emfields, self._q, self._m)
 
-        particles = particles_cxx()
+        prts_snapshots = particles_cxx()
 
-        boris.push(x0, u0, t_max, dt_max, gyro_max, particles)
+        boris.push(x0, u0, t_max, dt_max, gyro_max, prts_snapshots)
 
-        return particles.to_dataframe()
+        return prts_snapshots.to_dataframe()
 
 
 BorisIntegrator = BorisIntegrator_python

--- a/tests/test_particles.py
+++ b/tests/test_particles.py
@@ -1,13 +1,1 @@
 from __future__ import annotations
-
-import numpy as np
-from ggcmpy._openggcm.tracing import particle  # type: ignore[import-not-found]
-
-
-def test_particle_ctor():
-    prt = particle(x=np.array([0.0, 0.0, 0.0]), u=np.array([1.0, 0.0, 0.0]))
-    assert np.allclose(prt.x, np.array([0.0, 0.0, 0.0]))
-    assert np.allclose(prt.u, np.array([1.0, 0.0, 0.0]))
-    prt.x = [1.0, 2.0, 3.0]
-    assert np.allclose(prt.x, np.array([1.0, 2.0, 3.0]))
-    assert np.isclose(prt.gamma, np.sqrt(2.0))


### PR DESCRIPTION
This pull request refactors the particle tracing code to remove the `particle` class in favor of a more flexible `particles` class, updates the Boris integrator interface, and simplifies the Python/C++ bindings and tests. The changes streamline the codebase, improve data handling, and modernize the API for particle integration.

### Major API and Data Structure Changes

* Removed the `particle` class and all related methods, replacing it with a generalized `particles` class that manages multiple particles and their states using vectors. This includes removing the single-particle constructor, properties, and methods, and updating the API to work exclusively with `particles`. [[1]](diffhunk://#diff-d4aa7aca19f5703bcb69876fe8a67c8645728963c89f2408526cc31b481213a1L12-R42) [[2]](diffhunk://#diff-2a90038e562d5ce605014ad8a808f543af671a9cb4bac85833c19880a11ba5b0L270-R283) [[3]](diffhunk://#diff-efbb997ee3a86a9c3d6c18e04c89315fc808178071a6f519bc4110dfb5435f74L7-L19) [[4]](diffhunk://#diff-fbcd89f59e2b3cfdb6cfe102b1d8db9ea0009691e8031e2a23ead02c7b88588eL2-L13)

* Refactored the Boris integrator's `push` method to operate on `particles` instead of a single `particle`, adjusting both its signature and internal logic to handle particle arrays. [[1]](diffhunk://#diff-ed0e20ecbda8377bc8a737d91e448f59ece80f1fdd56260bcc9d4edca024678bL66-L83) [[2]](diffhunk://#diff-2a90038e562d5ce605014ad8a808f543af671a9cb4bac85833c19880a11ba5b0L293-R292)

### Python Bindings and Interface Updates

* Updated the Python bindings to support the new `particles` class, including a new constructor from pandas DataFrames and adapting the Boris integrator to work with DataFrame inputs and outputs. [[1]](diffhunk://#diff-9f383faa9413660d10ceea27743dbc7c4836918d427d1b39a762aa4cfec28ee6R306-R313) [[2]](diffhunk://#diff-9f383faa9413660d10ceea27743dbc7c4836918d427d1b39a762aa4cfec28ee6R323-R331)

* Modified the Boris integrator Python interface to repeatedly call the `push` method for each time step, collecting snapshots into a DataFrame for easier analysis and integration with Python workflows.

### Test Suite Cleanup

* Removed all tests and code that referenced the old `particle` class, as it no longer exists in the codebase. [[1]](diffhunk://#diff-efbb997ee3a86a9c3d6c18e04c89315fc808178071a6f519bc4110dfb5435f74L7-L19) [[2]](diffhunk://#diff-fbcd89f59e2b3cfdb6cfe102b1d8db9ea0009691e8031e2a23ead02c7b88588eL2-L13)