### PR TITLE
ci: run mypy in python 3.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
           - xarray<2025.07
           - xarray-adios2
           - pandas-stubs
-          - numpy<2.5
+          - numpy
 
   - repo: https://github.com/codespell-project/codespell
     rev: "v2.4.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ report.exclude_also = ['\.\.\.', 'if typing.TYPE_CHECKING:']
 [tool.mypy]
 files = ["src", "tests"]
 exclude = ["^src/ggcmpy/ggcm_tools/.*$"]
-python_version = "3.10"
+python_version = "3.12"
 warn_unused_configs = true
 strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]

--- a/src/ggcmpy/openggcm.py
+++ b/src/ggcmpy/openggcm.py
@@ -198,7 +198,7 @@ def timearray_to_dt64(time: NDArray[Any]) -> np.datetime64:
 
 def _dt64_to_timearray(times: ArrayLike, dtype: DTypeLike) -> ArrayLike:
     dt_times = pd.to_datetime(np.asarray(times))
-    return np.array(  # type: ignore[no-any-return]
+    return np.array(
         [
             dt_times.year,
             dt_times.month,


### PR DESCRIPTION
So we don't have to constrain to old numpy versions.