### PR TITLE
Improve gyro calculations and support max_steps in Python and C++

### DIFF
--- a/docs/tracing/dipole.ipynb
+++ b/docs/tracing/dipole.ipynb
@@ -174,7 +174,7 @@
     "gamma = 1.0 / np.sqrt(1 - (np.linalg.norm(v0) / constants.c) ** 2)\n",
     "u0 = gamma * v0 / constants.c\n",
     "\n",
-    "t_max = 100.0 * 2 * np.pi / om_ce  # [s]\n",
+    "t_final = 100.0 * 2 * np.pi / om_ce  # [s]\n",
     "dt = 1.0 / om_ce / 10.0"
    ]
   },
@@ -192,7 +192,7 @@
    "outputs": [],
    "source": [
     "boris = ggcmpy.tracing.BorisIntegrator(field, q=-constants.e, m=constants.m_e)\n",
-    "df = boris.integrate(x0, u0, t_max)"
+    "df = boris.integrate(x0, u0, t_final)"
    ]
   },
   {
@@ -209,7 +209,7 @@
    "outputs": [],
    "source": [
     "boris_cc = ggcmpy.tracing.BorisIntegrator(field_cc, q=-constants.e, m=constants.m_e)\n",
-    "df_cc = boris_cc.integrate(x0, u0, t_max)"
+    "df_cc = boris_cc.integrate(x0, u0, t_final)"
    ]
   },
   {
@@ -226,7 +226,7 @@
    "outputs": [],
    "source": [
     "boris_yee = ggcmpy.tracing.BorisIntegrator(field_yee, q=-constants.e, m=constants.m_e)\n",
-    "df_yee = boris_yee.integrate(x0, u0, t_max)"
+    "df_yee = boris_yee.integrate(x0, u0, t_final)"
    ]
   },
   {
@@ -249,7 +249,7 @@
     "boris_f2py = ggcmpy.tracing.BorisIntegrator_f2py(\n",
     "    field_yee, q=-constants.e, m=constants.m_e\n",
     ")\n",
-    "df_f2py = boris_f2py.integrate(x0, u0, 100 * t_max, dt_max=dt)"
+    "df_f2py = boris_f2py.integrate(x0, u0, 100 * t_final, dt_max=dt)"
    ]
   },
   {
@@ -360,11 +360,21 @@
     "plot_trajectories(plotter, dfs, line_width=1, color=\"gray\")\n",
     "plotter.show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# df_f2py.plot.scatter(x=\"x\", y=\"z\", c=\"time\", marker=\".\", colorbar=True)\n",
+    "df_f2py.plot(x=\"x\", y=\"z\", title=\"Particle trajectory in dipole field\");"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv-mac (3.12.12.final.0)",
+   "display_name": "ggcmpy (3.12.12)",
    "language": "python",
    "name": "python3"
   },
@@ -378,7 +388,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "version": "3.14.7"
   }
  },
  "nbformat": 4,

--- a/docs/tracing/openggcm.ipynb
+++ b/docs/tracing/openggcm.ipynb
@@ -111,9 +111,9 @@
     "u0 = gamma * v0 / constants.c\n",
     "\n",
     "dt = 2 * np.pi / om_ce / 20\n",
-    "t_max = 5000 * 2 * np.pi / om_ce  # [s]\n",
+    "t_final = 5000 * 2 * np.pi / om_ce  # [s]\n",
     "\n",
-    "df = boris.integrate(x0, u0, t_max, dt)\n",
+    "df = boris.integrate(x0, u0, t_final, dt)\n",
     "df"
    ]
   },

--- a/docs/tracing/openggcm.ipynb
+++ b/docs/tracing/openggcm.ipynb
@@ -97,7 +97,7 @@
     "boris = ggcmpy.tracing.BorisIntegrator_f2py(ds, q=-constants.e, m=constants.m_e)\n",
     "x0 = np.array([-5.0 * R_E, 0, 0])\n",
     "\n",
-    "B_x0 = boris._interpolator.B(x0)\n",
+    "B_x0 = boris._fields.B(x0)\n",
     "T_e = 1.0 * 1e3 * constants.e  # 1 keV in J\n",
     "v_e = np.sqrt(2 * T_e / constants.m_e)  # electron thermal speed\n",
     "v_e *= 10.0\n",
@@ -190,7 +190,7 @@
     "\n",
     "dfs = trace_field_lines(\n",
     "    seeds,\n",
-    "    boris._interpolator.B,\n",
+    "    boris._fields.B,\n",
     "    integrate_kwargs={\"r_min\": 2 * R_E, \"r_max\": 20.0 * R_E},\n",
     ")"
    ]
@@ -251,7 +251,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv-mac (3.12.12.final.0)",
+   "display_name": "ggcmpy (3.12.12)",
    "language": "python",
    "name": "python3"
   },
@@ -265,7 +265,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "version": "3.14.7"
   }
  },
  "nbformat": 4,

--- a/docs/tracing/simple-gyration.ipynb
+++ b/docs/tracing/simple-gyration.ipynb
@@ -141,7 +141,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df[\"E\"] = 0.5 * constants.m_e * np.linalg.norm(df[[\"vx\", \"vy\", \"vz\"]].values, axis=1)\n",
+    "df[\"E\"] = 0.5 * constants.m_e * np.linalg.norm(df[[\"ux\", \"uy\", \"uz\"]].values, axis=1)\n",
     "df.plot(x=\"time\", y=\"E\", title=\"Energy of the particle over time\");"
    ]
   }

--- a/docs/tracing/simple-gyration.ipynb
+++ b/docs/tracing/simple-gyration.ipynb
@@ -79,7 +79,7 @@
     "boris = ggcmpy.tracing.BorisIntegrator(fields, q, m)\n",
     "df = boris.integrate(x0, v0, t_max)\n",
     "# This limits the time step to 1% of the gyroperiod, ie., at least 100 steps per gyration\n",
-    "df2 = boris.integrate(x0, v0, t_max, gyro_max=0.01)"
+    "df2 = boris.integrate(x0, v0, t_max, dt_max_gyro=0.01)"
    ]
   },
   {
@@ -148,7 +148,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv-mac (3.12.12.final.0)",
+   "display_name": "ggcmpy (3.12.12)",
    "language": "python",
    "name": "python3"
   },
@@ -162,7 +162,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "version": "3.14.7"
   }
  },
  "nbformat": 4,

--- a/docs/tracing/simple-gyration.ipynb
+++ b/docs/tracing/simple-gyration.ipynb
@@ -74,12 +74,12 @@
     "x0 = np.array([0.0, 0.0, 0.0])  # [m]\n",
     "v0 = np.array([0.0, 100.0, 0.0])  # [m/s]\n",
     "om_ce = np.abs(q) * B_0 / m  # [rad/s]\n",
-    "t_max = 2 * np.pi / om_ce  # one gyroperiod # [s]\n",
+    "t_final = 2 * np.pi / om_ce  # one gyroperiod # [s]\n",
     "\n",
     "boris = ggcmpy.tracing.BorisIntegrator(fields, q, m)\n",
-    "df = boris.integrate(x0, v0, t_max)\n",
+    "df = boris.integrate(x0, v0, t_final)\n",
     "# This limits the time step to 1% of the gyroperiod, ie., at least 100 steps per gyration\n",
-    "df2 = boris.integrate(x0, v0, t_max, dt_max_gyro=0.01)"
+    "df2 = boris.integrate(x0, v0, t_final, dt_max_gyro=0.01)"
    ]
   },
   {

--- a/src/ggcmpy/backends/jrrle/particle_tracing.F90
+++ b/src/ggcmpy/backends/jrrle/particle_tracing.F90
@@ -207,7 +207,7 @@ contains
       this%m = m
    end subroutine boris_integrator_t_init
 
-   subroutine boris_integrator_t_integrate(this, x0, u0, get_E, get_B, t_max, dt_max, dt_max_gyro, data, n_out)
+   subroutine boris_integrator_t_integrate(this, x0, u0, get_E, get_B, t_final, dt_max, dt_max_gyro, data, n_out)
       class(boris_integrator_t), intent(in) :: this
       real, dimension(3), intent(in) :: x0
       real, dimension(3), intent(in) :: u0
@@ -221,7 +221,7 @@ contains
             real, dimension(3) :: B
          end function get_B
       end interface
-      real, intent(in) :: t_max, dt_max, dt_max_gyro
+      real, intent(in) :: t_final, dt_max, dt_max_gyro
       real, dimension(:, 0:), intent(out) :: data
       integer, intent(out) :: n_out
 
@@ -242,7 +242,7 @@ contains
       ! times, positions, velocities = [], [], []
       B = get_B(x)
       step = 0
-      do while (t < t_max)
+      do while (t < t_final)
          if (step < n_data) then
             data(1, step) = t
             data(2:4, step) = x
@@ -380,16 +380,16 @@ contains
       E = [interpolate_yee(x(1), x(2), x(3), 3), interpolate_yee(x(1), x(2), x(3), 4), interpolate_yee(x(1), x(2), x(3), 5)]
    end function get_E
 
-   subroutine boris_integrate(x0, v0, t_max, dt_max, dt_max_gyro, data, n_out, n_data)
+   subroutine boris_integrate(x0, v0, t_final, dt_max, dt_max_gyro, data, n_out, n_data)
       real, dimension(3), intent(in) :: x0
       real, dimension(3), intent(in) :: v0
-      real, intent(in) :: t_max, dt_max, dt_max_gyro
+      real, intent(in) :: t_final, dt_max, dt_max_gyro
       real, dimension(7, n_data) :: data
       integer, intent(out) :: n_out
       integer, intent(in) :: n_data
       !f2py intent(hide) :: n_data
 
-      call boris_integrator%integrate(x0, v0, get_E, get_B, t_max, dt_max, dt_max_gyro, data, n_out)
+      call boris_integrator%integrate(x0, v0, get_E, get_B, t_final, dt_max, dt_max_gyro, data, n_out)
    end subroutine boris_integrate
 
 end module particle_tracing_f2py

--- a/src/ggcmpy/backends/jrrle/particle_tracing.F90
+++ b/src/ggcmpy/backends/jrrle/particle_tracing.F90
@@ -207,7 +207,7 @@ contains
       this%m = m
    end subroutine boris_integrator_t_init
 
-   subroutine boris_integrator_t_integrate(this, x0, u0, get_E, get_B, t_max, dt_max, gyro_max, data, n_out)
+   subroutine boris_integrator_t_integrate(this, x0, u0, get_E, get_B, t_max, dt_max, dt_max_gyro, data, n_out)
       class(boris_integrator_t), intent(in) :: this
       real, dimension(3), intent(in) :: x0
       real, dimension(3), intent(in) :: u0
@@ -221,7 +221,7 @@ contains
             real, dimension(3) :: B
          end function get_B
       end interface
-      real, intent(in) :: t_max, dt_max, gyro_max
+      real, intent(in) :: t_max, dt_max, dt_max_gyro
       real, dimension(:, 0:), intent(out) :: data
       integer, intent(out) :: n_out
 
@@ -251,7 +251,7 @@ contains
          end if
 
          om_c = norm2(2. * qprime * B)  ! gyro frequency
-         dt = min(dt_max, gyro_max * 2.0 * pi / om_c)
+         dt = min(dt_max, dt_max_gyro * 2.0 * pi / om_c)
 
          gamma = sqrt(1.0 + sum(u**2))
          x = x + 0.5 * dt * u * c / gamma
@@ -380,16 +380,16 @@ contains
       E = [interpolate_yee(x(1), x(2), x(3), 3), interpolate_yee(x(1), x(2), x(3), 4), interpolate_yee(x(1), x(2), x(3), 5)]
    end function get_E
 
-   subroutine boris_integrate(x0, v0, t_max, dt_max, gyro_max, data, n_out, n_data)
+   subroutine boris_integrate(x0, v0, t_max, dt_max, dt_max_gyro, data, n_out, n_data)
       real, dimension(3), intent(in) :: x0
       real, dimension(3), intent(in) :: v0
-      real, intent(in) :: t_max, dt_max, gyro_max
+      real, intent(in) :: t_max, dt_max, dt_max_gyro
       real, dimension(7, n_data) :: data
       integer, intent(out) :: n_out
       integer, intent(in) :: n_data
       !f2py intent(hide) :: n_data
 
-      call boris_integrator%integrate(x0, v0, get_E, get_B, t_max, dt_max, gyro_max, data, n_out)
+      call boris_integrator%integrate(x0, v0, get_E, get_B, t_max, dt_max, dt_max_gyro, data, n_out)
    end subroutine boris_integrate
 
 end module particle_tracing_f2py

--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
@@ -73,7 +73,8 @@ public:
     double3 &u = prts.u(0);
 
     double3 B = emfields_.get().B(x);
-    double om_c = 2.0 * std::abs(qprime) * norm(B);
+    double gamma = std::sqrt(1.0 + norm2(u));
+    double om_c = 2.0 * std::abs(qprime) * norm(B) / gamma;
     double dt = std::min(dt_max, dt_max_gyro * 2.0 * constants::pi / om_c);
 
     while (t < t_max)

--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
@@ -63,7 +63,7 @@ public:
     u = up + dq * E / constants::c;
   }
 
-  void push(particles &prts, double t_max, double dt_max,
+  void push(particles &prts, double t_max, std::optional<double> dt_max,
             double dt_max_gyro) const
   {
     double qprime = 0.5 * q_ / m_;
@@ -75,7 +75,11 @@ public:
     double3 B = emfields_.get().B(x);
     double gamma = std::sqrt(1.0 + norm2(u));
     double om_c = 2.0 * std::abs(qprime) * norm(B) / gamma;
-    double dt = std::min(dt_max, dt_max_gyro * 2.0 * constants::pi / om_c);
+    double dt = dt_max_gyro * 2.0 * constants::pi / om_c;
+    if (dt_max.has_value())
+    {
+      dt = std::min(dt_max.value(), dt);
+    }
 
     while (t < t_max)
     {

--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
@@ -63,7 +63,7 @@ public:
     u = up + dq * E / constants::c;
   }
 
-  void push(particles &prts, std::optional<double> t_max,
+  void push(particles &prts, std::optional<double> t_final,
             std::optional<int> max_steps, std::optional<double> dt_max,
             double dt_max_gyro) const
   {
@@ -85,7 +85,7 @@ public:
     int step = 0;
     while (true)
     {
-      if (t_max.has_value() && t >= t_max.value())
+      if (t_final.has_value() && t >= t_final.value())
       {
         break;
       }

--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
@@ -63,7 +63,8 @@ public:
     u = up + dq * E / constants::c;
   }
 
-  void push(particles &prts, double t_max, double dt_max, double gyro_max) const
+  void push(particles &prts, double t_max, double dt_max,
+            double dt_max_gyro) const
   {
     double qprime = 0.5 * q_ / m_;
 
@@ -73,7 +74,7 @@ public:
 
     double3 B = emfields_.get().B(x);
     double om_c = 2.0 * std::abs(qprime) * norm(B);
-    double dt = std::min(dt_max, gyro_max * 2.0 * constants::pi / om_c);
+    double dt = std::min(dt_max, dt_max_gyro * 2.0 * constants::pi / om_c);
 
     while (t < t_max)
     {

--- a/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
+++ b/src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx
@@ -63,7 +63,8 @@ public:
     u = up + dq * E / constants::c;
   }
 
-  void push(particles &prts, double t_max, std::optional<double> dt_max,
+  void push(particles &prts, std::optional<double> t_max,
+            std::optional<int> max_steps, std::optional<double> dt_max,
             double dt_max_gyro) const
   {
     double qprime = 0.5 * q_ / m_;
@@ -81,12 +82,23 @@ public:
       dt = std::min(dt_max.value(), dt);
     }
 
-    while (t < t_max)
+    int step = 0;
+    while (true)
     {
+      if (t_max.has_value() && t >= t_max.value())
+      {
+        break;
+      }
+      if (max_steps.has_value() && step >= max_steps.value())
+      {
+        break;
+      }
+
       push_x(x, u, .5 * dt);
       push_u(x, u, dt);
       push_x(x, u, .5 * dt);
       t += dt;
+      step++;
     }
   }
 

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -290,5 +290,6 @@ NB_MODULE(_openggcm, m)
       .def(nb::init<const emfields &, double, double>(), "emfields"_a, "q"_a,
            "m"_a)
       .def("__repr__", &boris::repr)
-      .def("push", &boris::push, "prts"_a, "t_max"_a, "dt_max"_a, "gyro_max"_a);
+      .def("push", &boris::push, "prts"_a, "t_max"_a, "dt_max"_a,
+           "dt_max_gyro"_a = 0.1);
 }

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -1,6 +1,7 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/tuple.h>
 #include <nanobind/stl/vector.h>

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -291,7 +291,7 @@ NB_MODULE(_openggcm, m)
       .def(nb::init<const emfields &, double, double>(), "emfields"_a, "q"_a,
            "m"_a)
       .def("__repr__", &boris::repr)
-      .def("push", &boris::push, "prts"_a, "t_max"_a = nb::none(),
+      .def("push", &boris::push, "prts"_a, "t_final"_a = nb::none(),
            "max_steps"_a = nb::none(), "dt_max"_a = nb::none(),
            "dt_max_gyro"_a = 0.1);
 }

--- a/src/ggcmpy/libopenggcm/nanobind/bind.cxx
+++ b/src/ggcmpy/libopenggcm/nanobind/bind.cxx
@@ -291,6 +291,7 @@ NB_MODULE(_openggcm, m)
       .def(nb::init<const emfields &, double, double>(), "emfields"_a, "q"_a,
            "m"_a)
       .def("__repr__", &boris::repr)
-      .def("push", &boris::push, "prts"_a, "t_max"_a, "dt_max"_a,
+      .def("push", &boris::push, "prts"_a, "t_max"_a = nb::none(),
+           "max_steps"_a = nb::none(), "dt_max"_a = nb::none(),
            "dt_max_gyro"_a = 0.1);
 }

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -169,7 +169,7 @@ class boris_push_python:
         self,
         prts_df: pd.DataFrame,
         t_max: float,
-        dt_max: float,
+        dt_max: float | None = None,
         dt_max_gyro: float = 0.1,
     ) -> pd.DataFrame:
         """
@@ -186,7 +186,9 @@ class boris_push_python:
         u = prts_df.loc[0, ["ux", "uy", "uz"]].to_numpy()
         gamma = np.sqrt(1 + np.linalg.norm(u) ** 2)
         om_c = 2.0 * np.abs(qprime) * np.linalg.norm(B) / gamma
-        dt = min(dt_max, dt_max_gyro * 2.0 * np.pi / om_c)
+        dt = dt_max_gyro * 2.0 * np.pi / om_c
+        if dt_max is not None:
+            dt = min(dt_max, dt)
 
         while prts_df.loc[0, "time"] < t_max:  # type: ignore[operator]
             prts_df.loc[0, ["x", "y", "z"]] = self.push_x(

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -183,7 +183,9 @@ class boris_push_python:
         """
         qprime = 0.5 * self._q / self._m
         B = self._fields.B(prts_df.loc[0, ["x", "y", "z"]].to_numpy())
-        om_c = 2.0 * np.abs(qprime) * np.linalg.norm(B)
+        u = prts_df.loc[0, ["ux", "uy", "uz"]].to_numpy()
+        gamma = np.sqrt(1 + np.linalg.norm(u) ** 2)
+        om_c = 2.0 * np.abs(qprime) * np.linalg.norm(B) / gamma
         dt = min(dt_max, dt_max_gyro * 2.0 * np.pi / om_c)
 
         while prts_df.loc[0, "time"] < t_max:  # type: ignore[operator]

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -289,7 +289,7 @@ class BorisIntegratorBase:
         while prts_df.loc[0, "time"] < t_max:
             prts_df = boris_push.push(
                 prts_df,
-                t_max=prts_df.loc[0, "time"] + 1e-7,  # type: ignore[operator]
+                max_steps=1,
                 dt_max=dt_max,
                 dt_max_gyro=dt_max_gyro,
             )

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -168,7 +168,7 @@ class boris_push_python:
     def push(
         self,
         prts_df: pd.DataFrame,
-        t_max: float | None = None,
+        t_final: float | None = None,
         max_steps: int | None = None,
         dt_max: float | None = None,
         dt_max_gyro: float = 0.1,
@@ -178,7 +178,7 @@ class boris_push_python:
 
         Args:
             prts_df (pd.DataFrame): DataFrame containing particle states with columns ['time', 'x', 'y', 'z', 'ux', 'uy', 'uz'].
-            t_max (float | None): Maximum time to push the particles to.
+            t_final (float | None): Final time to push the particles to.
             max_steps (int | None): Maximum number of steps to take.
             dt_max (float | None): Maximum time step for the integration.
             dt_max_gyro (float): Maximum time step as fraction of the gyroperiod.
@@ -192,11 +192,11 @@ class boris_push_python:
         if dt_max is not None:
             dt = min(dt_max, dt)
 
-        assert t_max is not None or max_steps is not None
+        assert t_final is not None or max_steps is not None
 
         step = 0
         while True:
-            if t_max is not None and prts_df.loc[0, "time"] >= t_max:  # type: ignore[operator]
+            if t_final is not None and prts_df.loc[0, "time"] >= t_final:  # type: ignore[operator]
                 break
 
             if max_steps is not None and step >= max_steps:
@@ -277,7 +277,7 @@ class BorisIntegratorBase:
         self._m = m
         self._boris_push_cls = boris_push_cls
 
-    def integrate(self, x0, u0, t_max, dt_max=1.0, dt_max_gyro=0.1) -> pd.DataFrame:
+    def integrate(self, x0, u0, t_final, dt_max=1.0, dt_max_gyro=0.1) -> pd.DataFrame:
         boris_push = self._boris_push_cls(self._fields, self._q, self._m)
 
         prts_df = pd.DataFrame(
@@ -286,7 +286,7 @@ class BorisIntegratorBase:
         )
         snapshots = [prts_df.copy()]
 
-        while prts_df.loc[0, "time"] < t_max:
+        while prts_df.loc[0, "time"] < t_final:
             prts_df = boris_push.push(
                 prts_df,
                 max_steps=1,
@@ -316,7 +316,7 @@ class BorisIntegrator_python(BorisIntegratorBase):
         m (float): Particle mass.
 
     Methods:
-        integrate(x0, v0, t_max, dt) -> pd.DataFrame:
+        integrate(x0, v0, t_final, dt) -> pd.DataFrame:
             Integrates the particle trajectory using the Boris algorithm.
     """
 
@@ -350,7 +350,7 @@ class BorisIntegrator_f2py(BorisIntegratorBase):
         m (float): Particle mass.
 
     Methods:
-        integrate(x0, v0, t_max, dt) -> pd.DataFrame:
+        integrate(x0, v0, t_final, dt) -> pd.DataFrame:
             Integrates the particle trajectory using the Boris algorithm.
     """
 
@@ -364,11 +364,11 @@ class BorisIntegrator_f2py(BorisIntegratorBase):
 
         super().__init__(fields, q, m)
 
-    def integrate(self, x0, u0, t_max, dt_max=1.0, dt_max_gyro=0.1) -> pd.DataFrame:
-        n_steps = int(t_max / dt_max) + 2  # add some extra space for round-off issues
+    def integrate(self, x0, u0, t_final, dt_max=1.0, dt_max_gyro=0.1) -> pd.DataFrame:
+        n_steps = int(t_final / dt_max) + 2  # add some extra space for round-off issues
         data = np.zeros((7, n_steps), dtype=np.float32, order="F")
         n_out = _jrrle.particle_tracing_f2py.boris_integrate(
-            x0, u0, t_max, dt_max, dt_max_gyro, data
+            x0, u0, t_final, dt_max, dt_max_gyro, data
         )
         return pd.DataFrame(
             data.T[:n_out], columns=["time", "x", "y", "z", "ux", "uy", "uz"]
@@ -401,7 +401,7 @@ class boris_push_cxx(_openggcm.tracing.boris):  # type: ignore[misc]
     def push(
         self,
         prts_df: pd.DataFrame,
-        t_max: float | None = None,
+        t_final: float | None = None,
         max_steps: int | None = None,
         dt_max: float | None = None,
         dt_max_gyro: float = 0.1,
@@ -411,7 +411,7 @@ class boris_push_cxx(_openggcm.tracing.boris):  # type: ignore[misc]
 
         Args:
             prts_df (pd.DataFrame): DataFrame containing particle states with columns ['time', 'x', 'y', 'z', 'ux', 'uy', 'uz'].
-            t_max (float | None): Maximum time to push the particles to.
+            t_final (float | None): Final time to push the particles to.
             max_steps (int | None): Maximum number of steps to take.
             dt_max (float | None): Maximum time step for the integration.
             dt_max_gyro (float): Maximum time step as fraction of the gyroperiod.
@@ -419,7 +419,7 @@ class boris_push_cxx(_openggcm.tracing.boris):  # type: ignore[misc]
         prts = particles_cxx(prts_df)
         super().push(
             prts,
-            t_max=t_max,
+            t_final=t_final,
             max_steps=max_steps,
             dt_max=dt_max,
             dt_max_gyro=dt_max_gyro,
@@ -445,7 +445,7 @@ class BorisIntegrator_cxx(BorisIntegratorBase):
         m (float): Particle mass.
 
     Methods:
-        integrate(x0, v0, t_max, dt) -> pd.DataFrame:
+        integrate(x0, v0, t_final, dt) -> pd.DataFrame:
             Integrates the particle trajectory using the Boris algorithm.
     """
 

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -166,12 +166,25 @@ class boris_push_python:
         self._m = m
 
     def push(
-        self, prts_df: pd.DataFrame, t_max: float, dt_max: float, gyro_max: float
+        self,
+        prts_df: pd.DataFrame,
+        t_max: float,
+        dt_max: float,
+        dt_max_gyro: float = 0.1,
     ) -> pd.DataFrame:
+        """
+        Pushes the particles in `prts_df` from their current state.
+
+        Args:
+            prts_df (pd.DataFrame): DataFrame containing particle states with columns ['time', 'x', 'y', 'z', 'ux', 'uy', 'uz'].
+            t_max (float): Maximum time to push the particles to.
+            dt_max (float): Maximum time step for the integration.
+            dt_max_gyro (float): Maximum time step as fraction of the gyroperiod.
+        """
         qprime = 0.5 * self._q / self._m
         B = self._fields.B(prts_df.loc[0, ["x", "y", "z"]].to_numpy())
         om_c = 2.0 * np.abs(qprime) * np.linalg.norm(B)
-        dt = min(dt_max, gyro_max * 2.0 * np.pi / om_c)
+        dt = min(dt_max, dt_max_gyro * 2.0 * np.pi / om_c)
 
         while prts_df.loc[0, "time"] < t_max:  # type: ignore[operator]
             prts_df.loc[0, ["x", "y", "z"]] = self.push_x(
@@ -248,7 +261,7 @@ class BorisIntegratorBase:
         self._m = m
         self._boris_push_cls = boris_push_cls
 
-    def integrate(self, x0, u0, t_max, dt_max=1.0, gyro_max=0.1) -> pd.DataFrame:
+    def integrate(self, x0, u0, t_max, dt_max=1.0, dt_max_gyro=0.1) -> pd.DataFrame:
         boris_push = self._boris_push_cls(self._fields, self._q, self._m)
 
         prts_df = pd.DataFrame(
@@ -262,7 +275,7 @@ class BorisIntegratorBase:
                 prts_df,
                 prts_df.loc[0, "time"] + 1e-7,  # type: ignore[operator]
                 dt_max,
-                gyro_max,
+                dt_max_gyro,
             )
             snapshots.append(prts_df.copy())
 
@@ -335,11 +348,11 @@ class BorisIntegrator_f2py(BorisIntegratorBase):
 
         super().__init__(fields, q, m)
 
-    def integrate(self, x0, u0, t_max, dt_max=1.0, gyro_max=0.1) -> pd.DataFrame:
+    def integrate(self, x0, u0, t_max, dt_max=1.0, dt_max_gyro=0.1) -> pd.DataFrame:
         n_steps = int(t_max / dt_max) + 2  # add some extra space for round-off issues
         data = np.zeros((7, n_steps), dtype=np.float32, order="F")
         n_out = _jrrle.particle_tracing_f2py.boris_integrate(
-            x0, u0, t_max, dt_max, gyro_max, data
+            x0, u0, t_max, dt_max, dt_max_gyro, data
         )
         return pd.DataFrame(
             data.T[:n_out], columns=["time", "x", "y", "z", "ux", "uy", "uz"]
@@ -370,10 +383,19 @@ class boris_push_cxx(_openggcm.tracing.boris):  # type: ignore[misc]
     """Wrapper class for the C++ boris class, providing a convenient interface for particle integration."""
 
     def push(
-        self, prts_df: pd.DataFrame, t_max: float, dt_max: float, gyro_max: float
+        self, prts_df: pd.DataFrame, t_max: float, dt_max: float, dt_max_gyro: float
     ) -> pd.DataFrame:
+        """
+        Pushes the particles in `prts_df` from their current state.
+
+        Args:
+            prts_df (pd.DataFrame): DataFrame containing particle states with columns ['time', 'x', 'y', 'z', 'ux', 'uy', 'uz'].
+            t_max (float): Maximum time to push the particles to.
+            dt_max (float): Maximum time step for the integration.
+            dt_max_gyro (float): Maximum time step as fraction of the gyroperiod.
+        """
         prts = particles_cxx(prts_df)
-        super().push(prts, t_max, dt_max, gyro_max)
+        super().push(prts, t_max, dt_max, dt_max_gyro)
         return prts.to_dataframe()
 
 

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -178,9 +178,9 @@ class boris_push_python:
 
         Args:
             prts_df (pd.DataFrame): DataFrame containing particle states with columns ['time', 'x', 'y', 'z', 'ux', 'uy', 'uz'].
-            t_max (float): Maximum time to push the particles to.
+            t_max (float | None): Maximum time to push the particles to.
             max_steps (int | None): Maximum number of steps to take.
-            dt_max (float): Maximum time step for the integration.
+            dt_max (float | None): Maximum time step for the integration.
             dt_max_gyro (float): Maximum time step as fraction of the gyroperiod.
         """
         qprime = 0.5 * self._q / self._m
@@ -399,19 +399,31 @@ class boris_push_cxx(_openggcm.tracing.boris):  # type: ignore[misc]
     """Wrapper class for the C++ boris class, providing a convenient interface for particle integration."""
 
     def push(
-        self, prts_df: pd.DataFrame, t_max: float, dt_max: float, dt_max_gyro: float
+        self,
+        prts_df: pd.DataFrame,
+        t_max: float | None = None,
+        max_steps: int | None = None,
+        dt_max: float | None = None,
+        dt_max_gyro: float = 0.1,
     ) -> pd.DataFrame:
         """
         Pushes the particles in `prts_df` from their current state.
 
         Args:
             prts_df (pd.DataFrame): DataFrame containing particle states with columns ['time', 'x', 'y', 'z', 'ux', 'uy', 'uz'].
-            t_max (float): Maximum time to push the particles to.
-            dt_max (float): Maximum time step for the integration.
+            t_max (float | None): Maximum time to push the particles to.
+            max_steps (int | None): Maximum number of steps to take.
+            dt_max (float | None): Maximum time step for the integration.
             dt_max_gyro (float): Maximum time step as fraction of the gyroperiod.
         """
         prts = particles_cxx(prts_df)
-        super().push(prts, t_max, dt_max, dt_max_gyro)
+        super().push(
+            prts,
+            t_max=t_max,
+            max_steps=max_steps,
+            dt_max=dt_max,
+            dt_max_gyro=dt_max_gyro,
+        )
         return prts.to_dataframe()
 
 

--- a/src/ggcmpy/tracing/__init__.py
+++ b/src/ggcmpy/tracing/__init__.py
@@ -168,7 +168,8 @@ class boris_push_python:
     def push(
         self,
         prts_df: pd.DataFrame,
-        t_max: float,
+        t_max: float | None = None,
+        max_steps: int | None = None,
         dt_max: float | None = None,
         dt_max_gyro: float = 0.1,
     ) -> pd.DataFrame:
@@ -178,6 +179,7 @@ class boris_push_python:
         Args:
             prts_df (pd.DataFrame): DataFrame containing particle states with columns ['time', 'x', 'y', 'z', 'ux', 'uy', 'uz'].
             t_max (float): Maximum time to push the particles to.
+            max_steps (int | None): Maximum number of steps to take.
             dt_max (float): Maximum time step for the integration.
             dt_max_gyro (float): Maximum time step as fraction of the gyroperiod.
         """
@@ -190,7 +192,16 @@ class boris_push_python:
         if dt_max is not None:
             dt = min(dt_max, dt)
 
-        while prts_df.loc[0, "time"] < t_max:  # type: ignore[operator]
+        assert t_max is not None or max_steps is not None
+
+        step = 0
+        while True:
+            if t_max is not None and prts_df.loc[0, "time"] >= t_max:  # type: ignore[operator]
+                break
+
+            if max_steps is not None and step >= max_steps:
+                break
+
             prts_df.loc[0, ["x", "y", "z"]] = self.push_x(
                 prts_df.loc[0, ["x", "y", "z"]].to_numpy(),
                 prts_df.loc[0, ["ux", "uy", "uz"]].to_numpy(),
@@ -207,6 +218,7 @@ class boris_push_python:
                 0.5 * dt,
             )
             prts_df.loc[0, "time"] += dt
+            step += 1
 
         return prts_df
 
@@ -277,9 +289,9 @@ class BorisIntegratorBase:
         while prts_df.loc[0, "time"] < t_max:
             prts_df = boris_push.push(
                 prts_df,
-                prts_df.loc[0, "time"] + 1e-7,  # type: ignore[operator]
-                dt_max,
-                dt_max_gyro,
+                t_max=prts_df.loc[0, "time"] + 1e-7,  # type: ignore[operator]
+                dt_max=dt_max,
+                dt_max_gyro=dt_max_gyro,
             )
             snapshots.append(prts_df.copy())
 

--- a/src/ggcmpy/tracing/integrator.py
+++ b/src/ggcmpy/tracing/integrator.py
@@ -22,9 +22,8 @@ class boris_base:
     Base class for Boris particle pusher.
 
     Methods:
-        push(prts, t_max, dt_max, dt_max_gyro):
-            Pushes the particles in `prts` from their current state to a maximum time of `t_max`,
-            using a maximum time step of `dt_max` and a maximum gyro period of `dt_max_gyro`.
+        integrate(prts, ...):
+            Pushes the particles in `prts`.
     """
 
     def __init__(
@@ -42,7 +41,7 @@ class boris_base:
     def integrate(
         self,
         prts_df: pd.DataFrame,
-        t_max: float,
+        t_final: float | None = None,
         dt_max: float | None = None,
         dt_max_gyro: float = 0.1,
     ) -> pd.DataFrame:
@@ -50,7 +49,7 @@ class boris_base:
 
         snapshots = [prts_df]
 
-        while prts_df.iloc[0].time < t_max:
+        while prts_df.iloc[0].time < t_final:
             # hack to make the boris push do just one time step
             prts_df = boris.push(
                 prts_df,
@@ -68,8 +67,8 @@ class boris_python(boris_base):
     Boris particle pusher implemented in pure Python
 
     Methods:
-        push(prts, t_max, dt_max, dt_max_gyro):
-            Pushes the particles in `prts` from their current state to a maximum time of `t_max`,
+        push(prts, t_final, dt_max, dt_max_gyro):
+            Pushes the particles in `prts` from their current state to a maximum time of `t_final`,
             using a maximum time step of `dt_max` and a maximum gyro period of `dt_max_gyro`.
     """
 
@@ -90,8 +89,8 @@ class boris_cxx(boris_base):
     Boris particle pusher implemented in C++.
 
     Methods:
-        push(prts, t_max, dt_max, dt_max_gyro):
-            Pushes the particles in `prts` from their current state to a maximum time of `t_max`,
+        push(prts, t_final, dt_max, dt_max_gyro):
+            Pushes the particles in `prts` from their current state to a maximum time of `t_final`,
             using a maximum time step of `dt_max` and a maximum gyro period of `dt_max_gyro`.
     """
 

--- a/src/ggcmpy/tracing/integrator.py
+++ b/src/ggcmpy/tracing/integrator.py
@@ -22,9 +22,9 @@ class boris_base:
     Base class for Boris particle pusher.
 
     Methods:
-        push(prts, t_max, dt_max, gyro_max):
+        push(prts, t_max, dt_max, dt_max_gyro):
             Pushes the particles in `prts` from their current state to a maximum time of `t_max`,
-            using a maximum time step of `dt_max` and a maximum gyro period of `gyro_max`.
+            using a maximum time step of `dt_max` and a maximum gyro period of `dt_max_gyro`.
     """
 
     def __init__(
@@ -40,7 +40,7 @@ class boris_base:
         self._boris_push_cls = boris_push_cls
 
     def integrate(
-        self, prts_df: pd.DataFrame, t_max, dt_max=1.0, gyro_max=0.1
+        self, prts_df: pd.DataFrame, t_max, dt_max=1.0, dt_max_gyro=0.1
     ) -> pd.DataFrame:
         boris = self._boris_push_cls(self._fields, self._q, self._m)
 
@@ -48,7 +48,9 @@ class boris_base:
 
         while prts_df.iloc[0].time < t_max:
             # hack to make the boris push do just one time step
-            prts_df = boris.push(prts_df, prts_df.iloc[0].time + 1e-7, dt_max, gyro_max)
+            prts_df = boris.push(
+                prts_df, prts_df.iloc[0].time + 1e-7, dt_max, dt_max_gyro
+            )
             snapshots.append(prts_df)
 
         return pd.concat(snapshots, ignore_index=True)
@@ -59,9 +61,9 @@ class boris_python(boris_base):
     Boris particle pusher implemented in pure Python
 
     Methods:
-        push(prts, t_max, dt_max, gyro_max):
+        push(prts, t_max, dt_max, dt_max_gyro):
             Pushes the particles in `prts` from their current state to a maximum time of `t_max`,
-            using a maximum time step of `dt_max` and a maximum gyro period of `gyro_max`.
+            using a maximum time step of `dt_max` and a maximum gyro period of `dt_max_gyro`.
     """
 
     def __init__(
@@ -81,9 +83,9 @@ class boris_cxx(boris_base):
     Boris particle pusher implemented in C++.
 
     Methods:
-        push(prts, t_max, dt_max, gyro_max):
+        push(prts, t_max, dt_max, dt_max_gyro):
             Pushes the particles in `prts` from their current state to a maximum time of `t_max`,
-            using a maximum time step of `dt_max` and a maximum gyro period of `gyro_max`.
+            using a maximum time step of `dt_max` and a maximum gyro period of `dt_max_gyro`.
     """
 
     def __init__(

--- a/src/ggcmpy/tracing/integrator.py
+++ b/src/ggcmpy/tracing/integrator.py
@@ -53,7 +53,10 @@ class boris_base:
         while prts_df.iloc[0].time < t_max:
             # hack to make the boris push do just one time step
             prts_df = boris.push(
-                prts_df, prts_df.iloc[0].time + 1e-7, dt_max, dt_max_gyro
+                prts_df,
+                prts_df.iloc[0].time + 1e-7,
+                dt_max=dt_max,
+                dt_max_gyro=dt_max_gyro,
             )
             snapshots.append(prts_df)
 

--- a/src/ggcmpy/tracing/integrator.py
+++ b/src/ggcmpy/tracing/integrator.py
@@ -54,7 +54,7 @@ class boris_base:
             # hack to make the boris push do just one time step
             prts_df = boris.push(
                 prts_df,
-                prts_df.iloc[0].time + 1e-7,
+                max_steps=1,
                 dt_max=dt_max,
                 dt_max_gyro=dt_max_gyro,
             )

--- a/src/ggcmpy/tracing/integrator.py
+++ b/src/ggcmpy/tracing/integrator.py
@@ -40,7 +40,11 @@ class boris_base:
         self._boris_push_cls = boris_push_cls
 
     def integrate(
-        self, prts_df: pd.DataFrame, t_max, dt_max=1.0, dt_max_gyro=0.1
+        self,
+        prts_df: pd.DataFrame,
+        t_max: float,
+        dt_max: float | None = None,
+        dt_max_gyro: float = 0.1,
     ) -> pd.DataFrame:
         boris = self._boris_push_cls(self._fields, self._q, self._m)
 

--- a/tests/test_integrator.py
+++ b/tests/test_integrator.py
@@ -38,14 +38,14 @@ def test_boris_integrator_uniform(integrator):
     om_ce = gyro_frequency(B_0, q, m, gamma)
     r_ce = m * np.linalg.norm(u0) * constants.c / (np.abs(q) * B_0)  # [m]
 
-    t_max = 2 * np.pi / om_ce  # one gyroperiod # [s]
+    t_final = 2 * np.pi / om_ce  # one gyroperiod # [s]
     steps = 100
     prts_df = pd.DataFrame(
         np.array([[0.0, *x0, *u0]]), columns=["time", "x", "y", "z", "ux", "uy", "uz"]
     )
 
     boris = integrator(fields, q, m)
-    df = boris.integrate(prts_df, t_max=t_max, dt_max_gyro=1.0 / steps)
+    df = boris.integrate(prts_df, t_final=t_final, dt_max_gyro=1.0 / steps)
 
     assert len(df) >= steps
     assert len(df) <= steps + 2
@@ -82,14 +82,14 @@ def test_boris_integrator_dipole():
     print(f"B={B_0} [T] om_ce={om_ce:.2f} [1/s] r_ce={r_ce:.2f} [m]")
 
     t_ce = 2.0 * np.pi / om_ce  # [s]
-    t_max = 100.0 * t_ce  # [s]
+    t_final = 100.0 * t_ce  # [s]
 
     prts = pd.DataFrame(
         np.array([[0.0, *x0, *u0]]), columns=["time", "x", "y", "z", "ux", "uy", "uz"]
     )
 
     boris = ggcmpy.tracing.integrator.boris_cxx(fields, q, m)
-    df = boris.integrate(prts, t_max)
+    df = boris.integrate(prts, t_final=t_final)
 
     B_final = np.linalg.norm(fields.B(df.loc[df.index[-1], ["x", "y", "z"]].to_numpy()))
     om_ce_final = gyro_frequency(B_final, q, m, gamma)
@@ -99,7 +99,7 @@ def test_boris_integrator_dipole():
     df[df.time < 5.0 * t_ce].plot(
         x="x", y="z", style=".-", ax=axs[0], title="First 5 t_ce"
     )
-    df[df.time >= t_max - 5.0 * t_ce_final].plot(
+    df[df.time >= t_final - 5.0 * t_ce_final].plot(
         x="x", y="z", style=".-", ax=axs[1], title="Last 5 t_ce "
     )
     df.plot(x="x", y="z", style="-", ax=axs[2], title="All steps")

--- a/tests/test_integrator.py
+++ b/tests/test_integrator.py
@@ -40,7 +40,7 @@ def test_boris_integrator_uniform(integrator):
     )
 
     boris = integrator(fields, q, m)
-    df = boris.integrate(prts_df, t_max, dt)
+    df = boris.integrate(prts_df, t_max=t_max, dt_max=dt)
 
     assert len(df) >= steps
     assert len(df) <= steps + 2

--- a/tests/test_integrator.py
+++ b/tests/test_integrator.py
@@ -12,6 +12,10 @@ from ggcmpy.tracing import emfields, integrator
 R_E = constants.radius_earth  # [m]
 
 
+def gyro_frequency(B: float, q: float, m: float, gamma: float) -> float:
+    return np.abs(q) * B / (gamma * m)  # type: ignore[no-any-return]
+
+
 @pytest.mark.parametrize(
     "integrator",
     [
@@ -30,8 +34,10 @@ def test_boris_integrator_uniform(integrator):
     v0 = np.array([0.0, v_0, 0.0])  # [m/s]
     gamma = 1.0 / np.sqrt(1 - (np.linalg.norm(v0) / constants.c) ** 2)
     u0 = gamma * v0 / constants.c
-    om_ce = q * B_0 / (gamma * m)  # [rad/s]
+
+    om_ce = gyro_frequency(B_0, q, m, gamma)
     r_ce = m * np.linalg.norm(u0) * constants.c / (np.abs(q) * B_0)  # [m]
+
     t_max = 2 * np.pi / om_ce  # one gyroperiod # [s]
     steps = 100
     prts_df = pd.DataFrame(
@@ -56,9 +62,6 @@ def test_boris_integrator_uniform(integrator):
 @pytest.mark.mpl_image_compare
 def test_boris_integrator_dipole():
     """particle gyrating / bouncing in a dipole magnetic field"""
-
-    def gyro_frequency(B: float, q: float, m: float, gamma: float) -> float:
-        return np.abs(q) * B / (gamma * m)  # type: ignore[no-any-return]
 
     fields = emfields.dipole_cxx(m=constants.dipole_moment_earth)  # [A m^2]
 

--- a/tests/test_integrator.py
+++ b/tests/test_integrator.py
@@ -34,13 +34,12 @@ def test_boris_integrator_uniform(integrator):
     r_ce = m * np.linalg.norm(u0) * constants.c / (np.abs(q) * B_0)  # [m]
     t_max = 2 * np.pi / om_ce  # one gyroperiod # [s]
     steps = 100
-    dt = t_max / steps  # [s]
     prts_df = pd.DataFrame(
         np.array([[0.0, *x0, *u0]]), columns=["time", "x", "y", "z", "ux", "uy", "uz"]
     )
 
     boris = integrator(fields, q, m)
-    df = boris.integrate(prts_df, t_max=t_max, dt_max=dt)
+    df = boris.integrate(prts_df, t_max=t_max, dt_max_gyro=1.0 / steps)
 
     assert len(df) >= steps
     assert len(df) <= steps + 2

--- a/tests/test_particle_tracing.py
+++ b/tests/test_particle_tracing.py
@@ -79,12 +79,12 @@ def test_BorisIntegrator_uniform(Integrator):
     u0 = gamma * v0 / constants.c
     om_ce = q * B_0 / (gamma * m)  # [rad/s]
     r_ce = m * np.linalg.norm(u0) * constants.c / (np.abs(q) * B_0)  # [m]
-    t_max = 2 * np.pi / om_ce  # one gyroperiod # [s]
+    t_final = 2 * np.pi / om_ce  # one gyroperiod # [s]
     steps = 100
-    dt = t_max / steps  # [s]
+    dt = t_final / steps  # [s]
 
     boris = Integrator(emfields, q, m)
-    df = boris.integrate(x0, u0, t_max, dt)
+    df = boris.integrate(x0, u0, t_final=t_final, dt_max=dt)
 
     assert len(df) >= steps
     assert len(df) <= steps + 2
@@ -119,12 +119,12 @@ def test_BorisIntegrator(Integrator):
     u0 = gamma * v0 / constants.c
     om_ce = q * B_0 / (gamma * m)  # [rad/s]
     r_ce = m * np.linalg.norm(u0) * constants.c / (np.abs(q) * B_0)  # [m]
-    t_max = 2 * np.pi / om_ce  # one gyroperiod # [s]
+    t_final = 2 * np.pi / om_ce  # one gyroperiod # [s]
     steps = 100
-    dt = t_max / steps  # [s]
+    dt = t_final / steps  # [s]
 
     boris = Integrator(field_cc, q, m)
-    df = boris.integrate(x0, u0, t_max, dt)
+    df = boris.integrate(x0, u0, t_final=t_final, dt_max=dt)
 
     assert len(df) >= steps
     assert len(df) <= steps + 2
@@ -161,12 +161,12 @@ def test_BorisIntegratorYee(Integrator):
     u0 = gamma * v0 / constants.c
     om_ce = q * B_0 / (gamma * m)  # [rad/s]
     r_ce = m * np.linalg.norm(u0) * constants.c / (np.abs(q) * B_0)  # [m]
-    t_max = 2 * np.pi / om_ce  # one gyroperiod # [s]
+    t_final = 2 * np.pi / om_ce  # one gyroperiod # [s]
     steps = 100
-    dt = t_max / steps  # [s]
+    dt = t_final / steps  # [s]
 
     boris = Integrator(field_yee, q, m)
-    df = boris.integrate(x0, u0, t_max, dt)
+    df = boris.integrate(x0, u0, t_final=t_final, dt_max=dt)
 
     assert len(df) >= steps
     assert len(df) <= steps + 2


### PR DESCRIPTION
This pull request refactors the particle tracing integrator interfaces and examples for greater clarity, consistency, and flexibility. The main changes include standardizing the naming of integration time parameters from `t_max` to `t_final`, renaming and clarifying time step control arguments, and updating the corresponding documentation and example notebooks. The integrator interface now supports both time-based and step-based stopping conditions, and the code is more explicit about the meaning and usage of each parameter.

Key changes:

**API and Interface Improvements:**

* Standardized the main integration time parameter from `t_max` to `t_final` across Python, Fortran, and C++ backends, and updated all relevant function signatures and calls. (`src/ggcmpy/tracing/__init__.py`, `src/ggcmpy/backends/jrrle/particle_tracing.F90`, `src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx`, `src/ggcmpy/libopenggcm/nanobind/bind.cxx`) [[1]](diffhunk://#diff-9f383faa9413660d10ceea27743dbc7c4836918d427d1b39a762aa4cfec28ee6L251-R280) [[2]](diffhunk://#diff-9f383faa9413660d10ceea27743dbc7c4836918d427d1b39a762aa4cfec28ee6L338-R371) [[3]](diffhunk://#diff-c03c156c2bd38c81d362cb5d40713c36f278ec1805799d2ee85d6b0fd7c5cb20L210-R210) [[4]](diffhunk://#diff-c03c156c2bd38c81d362cb5d40713c36f278ec1805799d2ee85d6b0fd7c5cb20L224-R224) [[5]](diffhunk://#diff-c03c156c2bd38c81d362cb5d40713c36f278ec1805799d2ee85d6b0fd7c5cb20L245-R245) [[6]](diffhunk://#diff-ed0e20ecbda8377bc8a737d91e448f59ece80f1fdd56260bcc9d4edca024678bL66-R68) [[7]](diffhunk://#diff-2a90038e562d5ce605014ad8a808f543af671a9cb4bac85833c19880a11ba5b0L293-R296)
* Renamed the time step control argument from `gyro_max` to `dt_max_gyro` for clarity, and ensured it is consistently used as a fraction of the gyroperiod. (`src/ggcmpy/tracing/__init__.py`, `src/ggcmpy/backends/jrrle/particle_tracing.F90`, `src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx`) [[1]](diffhunk://#diff-9f383faa9413660d10ceea27743dbc7c4836918d427d1b39a762aa4cfec28ee6L251-R280) [[2]](diffhunk://#diff-c03c156c2bd38c81d362cb5d40713c36f278ec1805799d2ee85d6b0fd7c5cb20L224-R224) [[3]](diffhunk://#diff-ed0e20ecbda8377bc8a737d91e448f59ece80f1fdd56260bcc9d4edca024678bL75-R101)
* Enhanced the integrator interface to support both a final time (`t_final`) and a maximum number of steps (`max_steps`) as stopping criteria, improving flexibility and robustness. (`src/ggcmpy/tracing/__init__.py`, `src/ggcmpy/libopenggcm/include/openggcm/tracing/boris.hxx`, `src/ggcmpy/libopenggcm/nanobind/bind.cxx`) [[1]](diffhunk://#diff-9f383faa9413660d10ceea27743dbc7c4836918d427d1b39a762aa4cfec28ee6L169-L176) [[2]](diffhunk://#diff-ed0e20ecbda8377bc8a737d91e448f59ece80f1fdd56260bcc9d4edca024678bL66-R68) [[3]](diffhunk://#diff-2a90038e562d5ce605014ad8a808f543af671a9cb4bac85833c19880a11ba5b0L293-R296)

**Example and Documentation Updates:**

* Updated all example Jupyter notebooks to use the new `t_final` and `dt_max_gyro` parameter names and logic, and to reflect the new API. (`docs/tracing/dipole.ipynb`, `docs/tracing/openggcm.ipynb`, `docs/tracing/simple-gyration.ipynb`) [[1]](diffhunk://#diff-3914ea3082fbb22f52ff302f1ad58656f8112d3bb241757a2894317d6925a54fL177-R177) [[2]](diffhunk://#diff-3914ea3082fbb22f52ff302f1ad58656f8112d3bb241757a2894317d6925a54fL195-R195) [[3]](diffhunk://#diff-3914ea3082fbb22f52ff302f1ad58656f8112d3bb241757a2894317d6925a54fL212-R212) [[4]](diffhunk://#diff-3914ea3082fbb22f52ff302f1ad58656f8112d3bb241757a2894317d6925a54fL229-R229) [[5]](diffhunk://#diff-3914ea3082fbb22f52ff302f1ad58656f8112d3bb241757a2894317d6925a54fL252-R252) [[6]](diffhunk://#diff-84918c2c980780bce993c23b7f1b290de45647aebaa7c53dcfa123cfa3b8b23dL114-R116) [[7]](diffhunk://#diff-e87e3dafe270443a1afa1913a3fb25d28a79158203e31756d1f9cc8c9baeb3cbL77-R82)
* Improved docstrings and comments throughout the Python integrator code to clarify parameter usage and expected DataFrame formats. (`src/ggcmpy/tracing/__init__.py`)

**Minor Fixes and Miscellaneous:**

* Fixed a bug in the calculation of particle energy in the simple gyration example to use the correct velocity components. (`docs/tracing/simple-gyration.ipynb`)
* Updated notebook kernel and Python version metadata for consistency. (`docs/tracing/dipole.ipynb`, `docs/tracing/openggcm.ipynb`, `docs/tracing/simple-gyration.ipynb`) [[1]](diffhunk://#diff-3914ea3082fbb22f52ff302f1ad58656f8112d3bb241757a2894317d6925a54fL381-R391) [[2]](diffhunk://#diff-84918c2c980780bce993c23b7f1b290de45647aebaa7c53dcfa123cfa3b8b23dL268-R268) [[3]](diffhunk://#diff-e87e3dafe270443a1afa1913a3fb25d28a79158203e31756d1f9cc8c9baeb3cbL165-R165)
* Minor code cleanups and improvements, such as switching from internal to public field accessor methods. (`docs/tracing/openggcm.ipynb`) [[1]](diffhunk://#diff-84918c2c980780bce993c23b7f1b290de45647aebaa7c53dcfa123cfa3b8b23dL100-R100) [[2]](diffhunk://#diff-84918c2c980780bce993c23b7f1b290de45647aebaa7c53dcfa123cfa3b8b23dL193-R193)

These changes make the codebase more maintainable, the API clearer for users, and the documentation and examples more accurate and helpful.